### PR TITLE
[FEAT] input 컴포넌트 구현

### DIFF
--- a/src/assets/icons/AddIcon.tsx
+++ b/src/assets/icons/AddIcon.tsx
@@ -1,0 +1,19 @@
+export const AddIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+    >
+      <path
+        d="M12 8V16M8 12H16M5 3H19C20.1046 3 21 3.89543 21 5V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19V5C3 3.89543 3.89543 3 5 3Z"
+        stroke="#587DC9"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/src/assets/icons/DateIcon.tsx
+++ b/src/assets/icons/DateIcon.tsx
@@ -1,0 +1,20 @@
+export const DateIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    style={{ flexShrink: 0 }}
+  >
+    <path
+      d="M21 10.3333H3M21 6.77778V19.2222C21 20.2041 20.1046 21 19 21H5C3.89543 21 3 20.2041 3 19.2222V6.77778C3 5.79594 3.89543 5 5 5H19C20.1046 5 21 5.79594 21 6.77778Z"
+      stroke="#587DC9"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M7 2V7" stroke="#587DC9" strokeWidth="2" strokeLinecap="round" />
+    <path d="M17 2V7" stroke="#587DC9" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);

--- a/src/components/atoms/BorderBottomInput/BorderBottomInput.stories.ts
+++ b/src/components/atoms/BorderBottomInput/BorderBottomInput.stories.ts
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import BorderBottomInput from '.';
+
+const meta: Meta<typeof BorderBottomInput> = {
+  title: 'Atom/Input/BorderBottomInput',
+  component: BorderBottomInput,
+  tags: ['autodocs'],
+  parameters: {
+    componentSubtitle: '타일 제목 입력 필드 컴포넌트',
+    docs: {
+      description: {
+        component: `
+- 타일 제목을 입력받는 인풋 필드입니다.
+- 최대 글자 수 제한 및 에러 메시지 출력이 가능합니다.
+- 밑줄 색은 Primary 400, 에러 시 Warning 컬러입니다.
+- 에러 메시지는 항상 "50자 이내로 입력해주세요."로 고정됩니다.`,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BorderBottomInput>;
+
+export const Default: Story = {
+  args: {
+    value: '',
+    onChange: () => {},
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    value:
+      '타일 제목이 매우 길게 입력되어 50자를 초과한 경우 타일 제목이 매우 길게 입력되어 50자를 초과한 경우',
+    onChange: () => {},
+  },
+};

--- a/src/components/atoms/BorderBottomInput/index.tsx
+++ b/src/components/atoms/BorderBottomInput/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Text } from '@/components/atoms/Text';
+import { theme } from '@/styles/theme';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+  placeholder?: string;
+}
+
+const BorderBottomInput = ({
+  value,
+  onChange,
+  maxLength = 50,
+  placeholder = '타일 이름',
+}: Props) => {
+  const isError = value.length > maxLength;
+
+  return (
+    <Container>
+      <StyledInput
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        maxLength={maxLength}
+        placeholder={placeholder}
+      />
+      {isError && (
+        <Text typo="Caption_4" color="warning">
+          50자 이내로 입력해주세요.
+        </Text>
+      )}
+    </Container>
+  );
+};
+
+export default BorderBottomInput;
+
+const Container = styled.div`
+  width: 712px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const StyledInput = styled.input`
+  width: 100%;
+  padding-bottom: 4px;
+  background-color: transparent;
+  color: ${theme.palette.gray_700};
+  font: ${theme.typo.H3};
+
+  border: 0;
+  border-style: none;
+  border-bottom: 1px solid ${theme.palette.primary_400};
+  border-collapse: collapse;
+
+  &:focus {
+    outline: none;
+    border-bottom: 1px solid ${theme.palette.primary_400};
+  }
+`;

--- a/src/components/atoms/DateInput/DateInput.stories.tsx
+++ b/src/components/atoms/DateInput/DateInput.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import React, { useState } from 'react';
+import DateInput, { DateInputProps } from '.';
+
+const meta: Meta<typeof DateInput> = {
+  title: 'Atom/Input/DateInput',
+  component: DateInput,
+  tags: ['autodocs'],
+  parameters: {
+    componentSubtitle: '단일 날짜 입력 필드',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'active'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DateInput>;
+
+const Template = (args: Omit<DateInputProps, 'value' | 'onChange'>) => {
+  const [dateValue, setDateValue] = useState('2025-07-25');
+  return <DateInput {...args} value={dateValue} onChange={setDateValue} />;
+};
+
+export const Default: Story = {
+  render: Template,
+  args: {
+    variant: 'default',
+  },
+};
+
+export const Active: Story = {
+  render: Template,
+  args: {
+    variant: 'active',
+  },
+};

--- a/src/components/atoms/DateInput/index.tsx
+++ b/src/components/atoms/DateInput/index.tsx
@@ -1,0 +1,97 @@
+import React, { useRef } from 'react';
+import styled, { css } from 'styled-components';
+import { DateIcon } from '@/assets/icons/DateIcon';
+import { theme } from '@/styles/theme';
+
+export type Variant = 'default' | 'active';
+
+export interface DateInputProps {
+  value: string;
+  onChange: (val: string) => void;
+  variant?: Variant;
+}
+
+const DateInput = ({
+  value,
+  onChange,
+  variant = 'default',
+}: DateInputProps) => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  const openPicker = () => {
+    if (typeof ref.current?.showPicker === 'function') {
+      ref.current.showPicker();
+    } else {
+      ref.current?.focus();
+    }
+  };
+
+  return (
+    <Box variant={variant} onClick={openPicker}>
+      <StyledInput
+        ref={ref}
+        type="date"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+      />
+      <IconWrapper>
+        <DateIcon />
+      </IconWrapper>
+    </Box>
+  );
+};
+
+export default DateInput;
+
+const Box = styled.div<{ variant: Variant }>`
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  height: 40px;
+  width: fit-content;
+  border-radius: 10px;
+  background: ${theme.palette.gray_0};
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  color: ${theme.palette.gray_600};
+  cursor: pointer;
+
+  ${({ variant }) =>
+    variant === 'active'
+      ? css`
+          border: 1.5px solid ${theme.palette.primary_500};
+          box-shadow: 0px 4px 4px rgba(159, 198, 255, 0.25);
+        `
+      : css`
+          border: 1.5px solid ${theme.palette.primary_400};
+        `}
+`;
+
+const StyledInput = styled.input`
+  font: inherit;
+  color: inherit;
+  border: none;
+  background: transparent;
+
+  &::-webkit-calendar-picker-indicator {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    margin: 0;
+    padding: 0;
+    pointer-events: none;
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const IconWrapper = styled.div`
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/components/atoms/LongInput/LongInput.stories.tsx
+++ b/src/components/atoms/LongInput/LongInput.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import LongInput from '.';
+
+const meta: Meta<typeof LongInput> = {
+  title: 'Atom/Input/LongInput',
+  component: LongInput,
+  tags: ['autodocs'],
+  parameters: {
+    componentSubtitle: '타일 설명을 입력하는 멀티라인 필드',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'active', 'notified'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LongInput>;
+
+export const Default: Story = {
+  args: {
+    value: '',
+    onChange: () => {},
+    placeholder: '타일에 대한 간략한 설명을 입력해주세요.',
+    variant: 'default',
+  },
+};
+
+export const Active: Story = {
+  args: {
+    value: '설명을 입력 중입니다.',
+    onChange: () => {},
+    placeholder: '설명을 입력해주세요.',
+    variant: 'active',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    value:
+      '이 설명은 매우 길어서 200자를 넘을 수도 있는 상태를 테스트 중입니다. '.repeat(
+        10,
+      ),
+    onChange: () => {},
+    placeholder: '설명을 입력해주세요.',
+    variant: 'default',
+  },
+};
+
+export const Notified: Story = {
+  args: {
+    value: '',
+    onChange: () => {},
+    placeholder: '설명을 입력해주세요.',
+    variant: 'notified',
+    errorMessage: '설명을 입력해주세요.',
+  },
+};

--- a/src/components/atoms/LongInput/index.tsx
+++ b/src/components/atoms/LongInput/index.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { Text } from '@/components/atoms/Text';
+import { theme } from '@/styles/theme';
+
+type VariantType = 'default' | 'active' | 'notified' | 'error';
+
+interface LongInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+  placeholder?: string;
+  variant?: VariantType;
+  errorMessage?: string;
+}
+
+const LongInput = ({
+  value,
+  onChange,
+  maxLength = 200,
+  placeholder = '',
+  variant = 'default',
+  errorMessage,
+}: LongInputProps) => {
+  const isOverLimit = value.length > maxLength;
+  const resolvedVariant: VariantType = isOverLimit ? 'error' : variant;
+
+  const finalErrorMessage =
+    resolvedVariant === 'error'
+      ? '200자 내로 입력해주세요.'
+      : resolvedVariant === 'notified'
+        ? errorMessage
+        : undefined;
+
+  return (
+    <Outer>
+      <Wrapper variant={resolvedVariant}>
+        <Textarea
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          maxLength={maxLength}
+        />
+      </Wrapper>
+      {finalErrorMessage && (
+        <ErrorText>
+          <Text typo="Caption_4" color="warning">
+            {finalErrorMessage}
+          </Text>
+        </ErrorText>
+      )}
+    </Outer>
+  );
+};
+
+export default LongInput;
+
+const Outer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 480px;
+`;
+
+const Wrapper = styled.div<{ variant: VariantType }>`
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  background: ${theme.palette.gray_0};
+
+  ${({ variant }) => {
+    switch (variant) {
+      case 'active':
+        return css`
+          padding: 11px 208px 45px 16px;
+          border: 1.5px solid ${theme.palette.primary_500};
+          box-shadow: 0px 4px 4px rgba(159, 198, 255, 0.25);
+        `;
+      case 'notified':
+        return css`
+          padding: 11px 208px 45px 16px;
+          border: 1.5px solid ${theme.palette.warning};
+          box-shadow: 0px 4px 4px rgba(255, 86, 82, 0.25);
+        `;
+      case 'error':
+        return css`
+          padding: 11px 208px 45px 16px;
+          border: 1px solid ${theme.palette.primary_400};
+        `;
+      case 'default':
+      default:
+        return css`
+          padding: 11px 208px 45px 16px;
+          border: 1px solid ${theme.palette.primary_400};
+        `;
+    }
+  }}
+`;
+
+const Textarea = styled.textarea`
+  width: 100%;
+  resize: none;
+  border: none;
+  background: transparent;
+  outline: none;
+  font: ${theme.typo.Body_3};
+  color: ${theme.palette.gray_700};
+
+  &::placeholder {
+    color: ${theme.palette.gray_600};
+  }
+`;
+
+const ErrorText = styled.div`
+  padding-left: 16px;
+`;

--- a/src/components/atoms/ShortInput/ShortInput.stories.tsx
+++ b/src/components/atoms/ShortInput/ShortInput.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import ShortInput from '.';
+
+const meta: Meta<typeof ShortInput> = {
+  title: 'Atom/Input/ShortInput',
+  component: ShortInput,
+  tags: ['autodocs'],
+  parameters: {
+    componentSubtitle: '관련 타일/덱 검색 등에서 사용하는 짧은 단일 인풋 필드',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'active', 'error', 'notified'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ShortInput>;
+
+export const Default: Story = {
+  args: {
+    value: '',
+    onChange: () => {},
+    placeholder: '관련 타일 이름 입력',
+    variant: 'default',
+  },
+};
+
+export const Active: Story = {
+  args: {
+    value: '검색 중',
+    onChange: () => {},
+    placeholder: '검색 중',
+    variant: 'active',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    value: '관련타일이름이너무김',
+    onChange: () => {},
+    placeholder: '관련 타일 이름',
+    variant: 'error',
+    errorMessage: '링크 형태의 출처만 입력할 수 있어요.',
+  },
+};
+
+export const Notified: Story = {
+  args: {
+    value: '',
+    onChange: () => {},
+    placeholder: '출처를 입력해주세요.',
+    variant: 'notified',
+    errorMessage: '출처를 입력해주세요.',
+  },
+};

--- a/src/components/atoms/ShortInput/index.tsx
+++ b/src/components/atoms/ShortInput/index.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { Text } from '@/components/atoms/Text';
+import { theme } from '@/styles/theme';
+
+interface ShortInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  variant?: 'default' | 'tag' | 'active' | 'error' | 'notified';
+  errorMessage?: string;
+}
+
+const ShortInput = ({
+  value,
+  onChange,
+  placeholder = '',
+  variant = 'default',
+  errorMessage,
+}: ShortInputProps) => {
+  const showErrorText = variant === 'error' || variant === 'notified';
+
+  return (
+    <Outer>
+      <Wrapper variant={variant}>
+        <Input
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+        />
+      </Wrapper>
+      {showErrorText && errorMessage && (
+        <Text typo="Caption_4" color="warning">
+          {errorMessage}
+        </Text>
+      )}
+    </Outer>
+  );
+};
+
+export default ShortInput;
+
+const Outer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 480px;
+`;
+
+const Wrapper = styled.div<{ variant: ShortInputProps['variant'] }>`
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  background: ${theme.palette.gray_0};
+
+  ${({ variant }) => {
+    switch (variant) {
+      case 'tag':
+        return css`
+          padding: 7px 8px;
+          border: 1px solid ${theme.palette.primary_400};
+          gap: 10px;
+        `;
+      case 'active':
+        return css`
+          padding: 8px 208px 8px 16px;
+          border: 1.5px solid ${theme.palette.primary_500};
+          box-shadow: 0px 4px 4px rgba(159, 198, 255, 0.25);
+        `;
+      case 'notified':
+        return css`
+          padding: 8px 208px 8px 16px;
+          border: 1.5px solid ${theme.palette.warning};
+          box-shadow: 0px 4px 4px rgba(255, 86, 82, 0.25);
+        `;
+      case 'error':
+        return css`
+          padding: 8px 208px 8px 16px;
+          border: 1px solid ${theme.palette.primary_400};
+          gap: 6px;
+        `;
+      case 'default':
+      default:
+        return css`
+          padding: 8px 208px 8px 16px;
+          border: 1px solid ${theme.palette.primary_400};
+        `;
+    }
+  }}
+`;
+
+const Input = styled.input`
+  width: 100%;
+  border: none;
+  background: transparent;
+  outline: none;
+  font: ${theme.typo.Body_3};
+  color: ${theme.palette.gray_700};
+
+  &::placeholder {
+    color: ${theme.palette.gray_600};
+  }
+`;


### PR DESCRIPTION
## 📌 기능 설명
공통 입력 필드 컴포넌트들을 구현했습니다.

## 📌 구현 내용
- `ShortInput`: 태그 검색형 인풋
- `LongInput`: 설명 작성용 멀티라인 인풋
- `DateInput`: 날짜 선택 필드 (date 아이콘 사용)
- `BorderBottomInput`: 밑줄 스타일 인풋

## 📌 구현 결과
- variant(`default`, `active`, `error`, `notified`) 스타일 분기 처리
- DateInput은 showPicker() 사용해 달력 호출
- Storybook 스토리 작성 완료

### [ BorderBottomInput ]
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/2d527bd7-d7d8-4d8a-982f-bf236bcf5a4a" />

### [ DateInput ]
<img width="633" alt="image" src="https://github.com/user-attachments/assets/5d9f2947-b518-486f-97b1-8be6d18b6980" />

### [ LongInput ]
<img width="678" alt="image" src="https://github.com/user-attachments/assets/1ede1a1d-056f-44ad-89ea-504ddf467bff" />

### [ ShortInput ]
<img width="423" alt="image" src="https://github.com/user-attachments/assets/bdcfdf2d-0037-43bc-9ece-08452c3c78c9" />


## 📌 논의하고 싶은 점
현재 기본 브라우저 date picker(input[type="date"])를 사용해서 날짜 선택이 가능한 상태입니다!
Figma에 나온 것처럼 연도 → 월 → 일 순서로 선택하는 커스텀 DatePicker는 아직 구현 전입니다.