### PR TITLE
[FEAT] 검색 헤더바 수정 및 전체검색 연동

### DIFF
--- a/src/apis/searchApi.ts
+++ b/src/apis/searchApi.ts
@@ -7,14 +7,23 @@ export const searchApi = {
     });
     return res.data;
   },
+
   getRecent: async () => {
     const res = await authAxios.get("/search/recent");
     return res.data;
   },
+
   deleteRecent: async (keyword: string) => {
-    const response = await authAxios.delete(
+    const res = await authAxios.delete(
       `/search/recent/${encodeURIComponent(keyword)}`
     );
-    return response.data;
+    return res.data;
+  },
+
+  searchAll: async (query: string) => {
+    const res = await authAxios.get("/search", {
+      params: { query },
+    });
+    return res.data;
   },
 };

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { searchApi } from "@/apis/searchApi";
+import styled from "styled-components";
+import { SearchEvent, SearchPost } from "@/model/components/SearchType";
+import { theme } from "@/styles/theme";
+
+interface SearchProps {
+  query: string;
+}
+
+const SearchClient = ({ query }: SearchProps) => {
+  const [results, setResults] = useState<SearchPost[]>([]);
+  const [events, setEvents] = useState<SearchEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!query) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const res = await searchApi.searchAll(query);
+        if (res.isSuccess && res.data) {
+          setResults(res.data.posts);
+          setEvents(res.data.events);
+        } else {
+          setResults([]);
+          setEvents([]);
+        }
+      } catch (error) {
+        console.error(error);
+        setResults([]);
+        setEvents([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [query]);
+
+  return (
+    <Container>
+      <Wrapper>
+        {loading && <p>로딩 중...</p>}
+        {!loading && results.length === 0 && events.length === 0 && (
+          <p>검색 결과가 없습니다.</p>
+        )}
+        {!loading &&
+          results.map((post) => (
+            <ResultItem key={post.postId}>
+              <img src={post.mainImageUrl} alt={post.title} width={200} />
+              <h3>{post.title}</h3>
+              <p>{post.content}</p>
+              <p>작성자: {post.authorNickname}</p>
+            </ResultItem>
+          ))}
+        {!loading &&
+          events.map((event) => (
+            <EventItem key={event.groupId}>
+              <img
+                src={event.artistImageUrl}
+                alt={event.artistName}
+                width={200}
+              />
+              <h3>{event.name}</h3>
+              <p>아티스트: {event.artistName}</p>
+              <p>활동 유형: {event.activityTypes.join(", ")}</p>
+              <p>{event.description}</p>
+              <p>시작일: {event.startedAt}</p>
+            </EventItem>
+          ))}
+      </Wrapper>
+    </Container>
+  );
+};
+
+export default SearchClient;
+
+const Container = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  min-height: 100vh;
+  padding: 0 119px;
+`;
+
+const Wrapper = styled.div`
+  width: 1200px;
+  margin: 0 auto;
+  margin-bottom: 150px;
+`;
+
+const ResultItem = styled.div`
+  width: 100%;
+  padding: 32px;
+  border: 1px solid ${theme.palette.primary_300};
+  border-radius: 20px;
+  margin-bottom: 24px;
+  background: ${theme.palette.primary_20};
+`;
+
+const EventItem = styled(ResultItem)``;

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -5,12 +5,11 @@ import { searchApi } from "@/apis/searchApi";
 import styled from "styled-components";
 import { SearchEvent, SearchPost } from "@/model/components/SearchType";
 import { theme } from "@/styles/theme";
+import { useSearchParams } from "next/navigation";
 
-interface SearchProps {
-  query: string;
-}
-
-const SearchClient = ({ query }: SearchProps) => {
+const SearchClient = () => {
+  const searchParams = useSearchParams();
+  const query = searchParams.get("query") || "";
   const [results, setResults] = useState<SearchPost[]>([]);
   const [events, setEvents] = useState<SearchEvent[]>([]);
   const [loading, setLoading] = useState(false);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import SearchClient from "./SearchClient";
 
 export default function SearchPage() {
-  return <SearchClient />;
+  return (
+    <Suspense>
+      <SearchClient />
+    </Suspense>
+  );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import { searchApi } from "@/apis/searchApi";
+import styled from "styled-components";
+
+const SearchPage = () => {
+  const searchParams = useSearchParams();
+  const query = searchParams.get("query") || "";
+
+  useEffect(() => {
+    if (query) {
+      searchApi.searchAll(query);
+    }
+  }, [query]);
+
+  return (
+    <Container>
+      <Wrapper>검색 결과</Wrapper>
+    </Container>
+  );
+};
+
+export default SearchPage;
+
+const Container = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  min-height: 100vh;
+  padding: 0 119px;
+`;
+
+const Wrapper = styled.div`
+  width: 962px;
+  margin: 0 auto;
+  margin-bottom: 150px;
+`;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,38 +1,9 @@
-"use client";
+import SearchClient from "./SearchClient";
 
-import { useSearchParams } from "next/navigation";
-import { useEffect } from "react";
-import { searchApi } from "@/apis/searchApi";
-import styled from "styled-components";
+interface SearchPageProps {
+  searchParams: { query?: string };
+}
 
-const SearchPage = () => {
-  const searchParams = useSearchParams();
-  const query = searchParams.get("query") || "";
-
-  useEffect(() => {
-    if (query) {
-      searchApi.searchAll(query);
-    }
-  }, [query]);
-
-  return (
-    <Container>
-      <Wrapper>검색 결과</Wrapper>
-    </Container>
-  );
-};
-
-export default SearchPage;
-
-const Container = styled.div`
-  width: 100%;
-  overflow-x: auto;
-  min-height: 100vh;
-  padding: 0 119px;
-`;
-
-const Wrapper = styled.div`
-  width: 962px;
-  margin: 0 auto;
-  margin-bottom: 150px;
-`;
+export default function SearchPage({ searchParams }: SearchPageProps) {
+  return <SearchClient query={searchParams.query || ""} />;
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,9 +1,5 @@
 import SearchClient from "./SearchClient";
 
-interface SearchPageProps {
-  searchParams: { query?: string };
-}
-
-export default function SearchPage({ searchParams }: SearchPageProps) {
-  return <SearchClient query={searchParams.query || ""} />;
+export default function SearchPage() {
+  return <SearchClient />;
 }

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -78,7 +78,7 @@ export const Search = () => {
     ].slice(0, 10);
     setRecentKeywords(newKeywords);
 
-    router.push(`/search?query=${encodeURIComponent(keyword)}`);
+    window.location.href = `/search?query=${encodeURIComponent(keyword)}`;
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -125,7 +125,11 @@ export const Search = () => {
         />
       )}
       {isFocused && value.trim() && (
-        <SuggestDropdown keyword={value} suggestions={suggestions} />
+        <SuggestDropdown
+          keyword={value}
+          suggestions={suggestions}
+          onTagClick={handleTagClick}
+        />
       )}
     </SearchInputWrapper>
   );

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -116,6 +116,7 @@ export const Search = () => {
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}
         $isDropdownOpen={isFocused}
+        spellCheck="false"
       />
       {isFocused && !value.trim() && (
         <RecentSearchDropdown
@@ -163,6 +164,7 @@ const SearchInput = styled.input<{ $isDropdownOpen: boolean }>`
   border-bottom: ${({ $isDropdownOpen }) =>
     $isDropdownOpen ? "none" : `1px solid ${theme.palette.gray_400}`};
   outline: none;
+  appearance: none;
   font-family: "Pretendard-Regular";
   font-size: 16px;
   line-height: 150%;

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -78,7 +78,7 @@ export const Search = () => {
     ].slice(0, 10);
     setRecentKeywords(newKeywords);
 
-    window.location.href = `/search?query=${encodeURIComponent(keyword)}`;
+    router.push(`/search?query=${encodeURIComponent(keyword)}`);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -78,6 +78,8 @@ export const Search = () => {
     ].slice(0, 10);
     setRecentKeywords(newKeywords);
 
+    setIsFocused(false);
+
     router.push(`/search?query=${encodeURIComponent(keyword)}`);
   };
 

--- a/src/components/Search/SuggestDropdown.tsx
+++ b/src/components/Search/SuggestDropdown.tsx
@@ -4,16 +4,19 @@ import { theme } from "@/styles/theme";
 interface Props {
   keyword: string;
   suggestions: string[];
+  onTagClick: (keyword: string) => void;
 }
 
-export const SuggestDropdown = ({ suggestions }: Props) => {
+export const SuggestDropdown = ({ suggestions, onTagClick }: Props) => {
   return (
     <DropdownWrapper>
       <Divider />
       <DropDiv>
         {suggestions.length > 0 ? (
           suggestions.map((item, idx) => (
-            <DropdownItem key={idx}>{item}</DropdownItem>
+            <DropdownItem key={idx} onClick={() => onTagClick(item)}>
+              {item}
+            </DropdownItem>
           ))
         ) : (
           <NoSuggestion>추천 검색어가 없습니다</NoSuggestion>

--- a/src/model/components/SearchType.ts
+++ b/src/model/components/SearchType.ts
@@ -1,0 +1,34 @@
+export interface SearchPost {
+  postId: number;
+  groupId: string;
+  title: string;
+  content: string;
+  mainImageUrl: string;
+  createdAt: string;
+  likeCount: number;
+  commentCount: number;
+  authorId: number;
+  authorNickname: string;
+  authorProfileImageUrl: string;
+}
+
+export interface SearchEvent {
+  groupId: string;
+  name: string;
+  activityTypes: string[];
+  artistImageUrl: string;
+  artistName: string;
+  description: string;
+  startedAt: string;
+}
+
+export interface SearchResponse {
+  artistCount: number;
+  artists: string[];
+  userCount: number;
+  users: string[];
+  postCount: number;
+  posts: SearchPost[];
+  eventCount: number;
+  events: Event[];
+}


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
검색 헤더바 수정 및 검색 페이지 전체검색 api 연결해두었습니다.

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- 검색 헤더바 추천검색어 클릭 시 전체검색 결과 조회 화면으로 넘어가도록 수정
- 전체 검색 api를 연결하여 검색 헤더바에서 검색하면 전체 검색 결과 조회되도록
- 검색 인풋의 spellcheck 빨간줄 해제


## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
![searchgif2](https://github.com/user-attachments/assets/1a3180ba-61d1-4ce5-946c-fb2e3183efb5)
위 gif처럼 동작합니다.
<br/>

<img width="1919" height="859" alt="스크린샷 2025-09-18 151247" src="https://github.com/user-attachments/assets/8f118a71-c833-48f9-b2d1-d073dc5f2c22" />
지금은 조회되는지 확인하려고 api 연동만 해두고 UI는 이렇게 그냥 막 띄워둔 상태라 피그마대로 수정할 예정입니다.

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
