### PR TITLE
[FEAT] 전체 검색 페이지 UI 및 기능 구현

### DIFF
--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -7,10 +7,13 @@ import {
   SearchArtist,
   SearchEvent,
   SearchPost,
+  SearchResponse,
   SearchUser,
 } from "@/model/components/SearchType";
 import { theme } from "@/styles/theme";
 import { useSearchParams } from "next/navigation";
+import { SearchHeader } from "@/components/Search/SearchResult/SearchHeader";
+import { DeckResult } from "@/components/Search/SearchResult/DeckResult";
 
 const SearchClient = () => {
   const searchParams = useSearchParams();
@@ -20,6 +23,14 @@ const SearchClient = () => {
   const [results, setResults] = useState<SearchPost[]>([]);
   const [events, setEvents] = useState<SearchEvent[]>([]);
   const [loading, setLoading] = useState(false);
+  const [response, setResponse] = useState<SearchResponse | null>(null);
+
+  const searchCount = response
+    ? response.artistCount +
+      response.userCount +
+      response.postCount +
+      response.eventCount
+    : 0;
 
   useEffect(() => {
     if (!query) return;
@@ -29,6 +40,7 @@ const SearchClient = () => {
       try {
         const res = await searchApi.searchAll(query);
         if (res.isSuccess && res.data) {
+          setResponse(res.data);
           setResults(res.data.posts);
           setEvents(res.data.events);
           setArtists(res.data.artists);
@@ -59,30 +71,12 @@ const SearchClient = () => {
         {!loading && results.length === 0 && events.length === 0 && (
           <p>검색 결과가 없습니다.</p>
         )}
-        {!loading &&
-          results.map((post) => (
-            <ResultItem key={post.postId}>
-              <img src={post.mainImageUrl} alt={post.title} width={200} />
-              <h3>{post.title}</h3>
-              <p>{post.content}</p>
-              <p>작성자: {post.authorNickname}</p>
-            </ResultItem>
-          ))}
-        {!loading &&
-          events.map((event) => (
-            <EventItem key={event.groupId}>
-              <img
-                src={event.artistImageUrl}
-                alt={event.artistName}
-                width={200}
-              />
-              <h3>{event.name}</h3>
-              <p>아티스트: {event.artistName}</p>
-              <p>활동 유형: {event.activityTypes.join(", ")}</p>
-              <p>{event.description}</p>
-              <p>시작일: {event.startedAt}</p>
-            </EventItem>
-          ))}
+        {!loading && response && (
+          <>
+            <SearchHeader searchCount={searchCount} />
+            <DeckResult artistCount={response.artistCount} artists={artists} />
+          </>
+        )}
       </Wrapper>
     </Container>
   );
@@ -98,9 +92,11 @@ const Container = styled.div`
 `;
 
 const Wrapper = styled.div`
+  display: flex;
   width: 1200px;
-  margin: 0 auto;
-  margin-bottom: 150px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
 `;
 
 const ResultItem = styled.div`

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -3,13 +3,20 @@
 import { useEffect, useState } from "react";
 import { searchApi } from "@/apis/searchApi";
 import styled from "styled-components";
-import { SearchEvent, SearchPost } from "@/model/components/SearchType";
+import {
+  SearchArtist,
+  SearchEvent,
+  SearchPost,
+  SearchUser,
+} from "@/model/components/SearchType";
 import { theme } from "@/styles/theme";
 import { useSearchParams } from "next/navigation";
 
 const SearchClient = () => {
   const searchParams = useSearchParams();
   const query = searchParams.get("query") || "";
+  const [artists, setArtists] = useState<SearchArtist[]>([]);
+  const [users, setUsers] = useState<SearchUser[]>([]);
   const [results, setResults] = useState<SearchPost[]>([]);
   const [events, setEvents] = useState<SearchEvent[]>([]);
   const [loading, setLoading] = useState(false);
@@ -24,9 +31,14 @@ const SearchClient = () => {
         if (res.isSuccess && res.data) {
           setResults(res.data.posts);
           setEvents(res.data.events);
+          setArtists(res.data.artists);
+          setUsers(res.data.users);
+          console.log(res.data);
         } else {
           setResults([]);
           setEvents([]);
+          setArtists([]);
+          setUsers([]);
         }
       } catch (error) {
         console.error(error);

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -16,6 +16,7 @@ import { SearchHeader } from "@/components/Search/SearchResult/SearchHeader";
 import { DeckResult } from "@/components/Search/SearchResult/DeckResult";
 import { UserResult } from "@/components/Search/SearchResult/UserResult";
 import { MyTileResult } from "@/components/Search/SearchResult/MyTileResult";
+import { TimeTileResult } from "@/components/Search/SearchResult/TimeTileResult";
 
 const SearchClient = () => {
   const searchParams = useSearchParams();
@@ -80,6 +81,11 @@ const SearchClient = () => {
               posts={results}
               highlightWord={query}
             />
+            <TimeTileResult
+              eventCount={response.eventCount}
+              events={events}
+              highlightWord={query}
+            />
           </>
         )}
       </Wrapper>
@@ -94,10 +100,12 @@ const Container = styled.div`
   overflow-x: auto;
   min-height: 100vh;
   padding: 0 119px;
+  margin-bottom: 83px;
 `;
 
 const Wrapper = styled.div`
   display: flex;
+  margin: 0 auto;
   width: 1200px;
   flex-direction: column;
   align-items: flex-start;

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -75,7 +75,11 @@ const SearchClient = () => {
             <SearchHeader searchCount={searchCount} />
             <DeckResult artistCount={response.artistCount} artists={artists} />
             <UserResult userCount={response.userCount} users={users} />
-            <MyTileResult postCount={response.postCount} posts={results} />
+            <MyTileResult
+              postCount={response.postCount}
+              posts={results}
+              highlightWord={query}
+            />
           </>
         )}
       </Wrapper>

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -14,6 +14,7 @@ import { theme } from "@/styles/theme";
 import { useSearchParams } from "next/navigation";
 import { SearchHeader } from "@/components/Search/SearchResult/SearchHeader";
 import { DeckResult } from "@/components/Search/SearchResult/DeckResult";
+import { UserResult } from "@/components/Search/SearchResult/UserResult";
 
 const SearchClient = () => {
   const searchParams = useSearchParams();
@@ -68,13 +69,11 @@ const SearchClient = () => {
     <Container>
       <Wrapper>
         {loading && <p>로딩 중...</p>}
-        {!loading && results.length === 0 && events.length === 0 && (
-          <p>검색 결과가 없습니다.</p>
-        )}
         {!loading && response && (
           <>
             <SearchHeader searchCount={searchCount} />
             <DeckResult artistCount={response.artistCount} artists={artists} />
+            <UserResult userCount={response.userCount} users={users} />
           </>
         )}
       </Wrapper>

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -15,6 +15,7 @@ import { useSearchParams } from "next/navigation";
 import { SearchHeader } from "@/components/Search/SearchResult/SearchHeader";
 import { DeckResult } from "@/components/Search/SearchResult/DeckResult";
 import { UserResult } from "@/components/Search/SearchResult/UserResult";
+import { MyTileResult } from "@/components/Search/SearchResult/MyTileResult";
 
 const SearchClient = () => {
   const searchParams = useSearchParams();
@@ -74,6 +75,7 @@ const SearchClient = () => {
             <SearchHeader searchCount={searchCount} />
             <DeckResult artistCount={response.artistCount} artists={artists} />
             <UserResult userCount={response.userCount} users={users} />
+            <MyTileResult postCount={response.postCount} posts={results} />
           </>
         )}
       </Wrapper>

--- a/src/assets/icons/RightArrow.tsx
+++ b/src/assets/icons/RightArrow.tsx
@@ -1,0 +1,21 @@
+export const RightArrow = () => {
+  return (
+    <>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+      >
+        <path
+          d="M9 18L15 12L9 6"
+          stroke="#1F3D88"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </>
+  );
+};

--- a/src/components/IndividualRecord/RecordPost/RecordPost.stories.ts
+++ b/src/components/IndividualRecord/RecordPost/RecordPost.stories.ts
@@ -1,10 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import RecordPost from './index';
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import RecordPost from "./index";
 
 const meta: Meta<typeof RecordPost> = {
-  title: 'Components/RecordPost',
+  title: "Components/RecordPost",
   component: RecordPost,
-  tags: ['autodocs'],
+  tags: ["autodocs"],
 };
 
 export default meta;
@@ -13,22 +13,15 @@ type Story = StoryObj<typeof RecordPost>;
 
 export const Default: Story = {
   args: {
-    profileImage: '/record-image.png',
-    username: '레드벨벳짱',
-    visibility: '전체공개',
-    title:
-      '트리플에스트리플에스트리플에스트리플에스트리플에스트리플에스트리플에스트리플에스트리플에스트리플에스',
-    content:
-      '다만 MY WORLD에서는 SM엔터테인먼트 경영권 분쟁의 영향으로 그룹의 전체적인 \n콘셉트를 기획했던 이수만과 유영진이 프로듀싱에서 손을 뗀 뒤 SM을 떠난 것의 여파인지, \n그동안 선보였던 강렬하고 난해한 SMP가 아닌 멤버들의 나이대에 걸맞은 풋풋한 하이틴 콘셉트로 전환하며\n\n이미지 변신을 시도했다. SMP에 열광하는 코어 팬덤은 확보했지만 대중성은 이전의 SM 걸그룹들보다 못하다는 평가도 적지 않게 있었음을 고려하면, 일반 대중들의 진입 장벽을 낮추기 위해 이전보다 대중성을 더욱 많이 가미한 콘셉트를 시도한 것으로 보이나, \n\n이것이 일시적인 실험일지 아니면 완전한 변화일지는 더 지켜볼 일이다. 다만 광야 콘셉트를 완전히 버린 것은 아니고 \n잠깐 REAL WORLD로 돌아와 휴식을 취하는 콘셉트라고 한다. 실제로 Girls의 가사 중\n nævis on the REAL MY WORLD라는 파트가 있는 것을 봐선 하이틴 콘셉트까지는 아닐지라도 어느 정도 예정된 수순이었던 것으로 보인다.',
-    images: [
-      '/record-image.png',
-      '/record-image.png',
-      '/record-image.png',
-      '/record-image.png',
-      '/record-image.png',
-      '/record-image.png',
-    ],
+    profileImage: "/record-image.png",
+    username: "레드벨벳짱",
+    visibility: "전체공개",
+    title: "테스트 제목",
+    content: "테스트 내용",
+    images: ["/record-image.png", "/record-image.png"],
     likes: 99,
     comments: 12,
+    scrapCount: 5,
+    onDeleteSuccess: () => console.log("삭제 성공!"),
   },
 };

--- a/src/components/IndividualRecord/RecordPost/index.tsx
+++ b/src/components/IndividualRecord/RecordPost/index.tsx
@@ -8,32 +8,31 @@ import { ChatIcon } from "@/assets/icons/ChatIcon";
 import { ScrapIcon1 } from "@/assets/icons/ScrapIcon1";
 import { ScrapIconFill } from "@/assets/icons/ScrapIconFill";
 import { RightArrowIcon1 } from "@/assets/icons/RightArrowIcon1";
-import { LeftArrowIcon } from "@/assets/icons/LeftArrowIcon";
 import { MoreIcon } from "@/assets/icons/MoreIcon";
 import ScrapModal from "@/components/Scrap/ScrapModal";
 import { postApi } from "@/apis/postApi";
 import { scrapApi } from "@/apis/scrapApi";
 import CommentsSection from "@/components/atoms/Comments";
-import { useRouter } from "next/navigation";
 import { HeartFillIcon } from "@/assets/icons/HeartFillIcon";
+import { LeftArrowIcon } from "@/assets/icons/LeftArrowIcon";
 
 interface RecordPostProps {
   postId: number;
   profileImage: string;
-  username: string; // 작성자 닉네임(authorNickname)
-  currentNickname?: string; // 내 닉네임(nickname)
+  username: string;
+  currentNickname?: string;
   roleImageUrl?: string;
   visibility: string;
-  date: string; // YYYY-MM-DD
+  date: string;
   title: string;
   content: string;
   images: string[];
   likes: number;
   comments: number;
   scrapCount?: number;
-  commentsData?: any[]; // 외부에서 주입 시 사용 (없어도 됨)
+  commentsData?: any[];
   onImageClick?: (index: number) => void;
-  onDeleteSuccess?: () => void;
+  onDeleteSuccess?: () => void; // 삭제 콜백
 }
 
 const RecordPost = ({
@@ -54,25 +53,22 @@ const RecordPost = ({
   onImageClick,
   onDeleteSuccess,
 }: RecordPostProps) => {
-  const router = useRouter();
   const imageGridRef = useRef<HTMLDivElement>(null);
 
-  // 상세 데이터(표시용) 상태
   const [headerName, setHeaderName] = useState(username);
   const [headerProfile, setHeaderProfile] = useState(profileImage);
   const [theDate, setTheDate] = useState(date);
   const [imgs, setImgs] = useState(images);
   const [visibilityState, setVisibilityState] = useState(visibility);
 
-  // 카운트/상태
-  const [commentCount, setCommentCount] = useState<number>(
+  const [commentCount, setCommentCount] = useState(
     (commentsData?.length ?? 0) || comments || 0
   );
   const [likeCount, setLikeCount] = useState(likes);
-  const [liked, setLiked] = useState(false); // 상세 스펙에 isLiked 없으므로 false 시작
+  const [liked, setLiked] = useState(false);
   const [likeLoading, setLikeLoading] = useState(false);
 
-  const [scrapped, setScrapped] = useState(false); // 내 스크랩 여부(아이콘 색칠)
+  const [scrapped, setScrapped] = useState(false);
   const [scrapCnt, setScrapCnt] = useState(scrapCount);
   const [scrapOpen, setScrapOpen] = useState(false);
 
@@ -85,17 +81,13 @@ const RecordPost = ({
   const maxReportLen = 200;
 
   const owned = (currentNickname ?? "") === (username ?? "");
-  // 댓글 카운트(CommentsSection과 동기화)
 
-  // 유틸
   const pick = (k: string) =>
     (typeof window === "undefined" ? "" : localStorage.getItem(k) || "").trim();
 
-  // ✅ 현재 로그인 유저 닉네임/프로필 (댓글 낙관적 렌더용)
   const currentUserName = pick("commenterNickname");
   const currentUserAvatarUrl = pick("commenterProfileImageUrl");
 
-  // 날짜 포맷
   const formatDateYMD = (iso?: string) => {
     if (!iso) return "";
     const d = new Date(iso);
@@ -103,66 +95,13 @@ const RecordPost = ({
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
   };
 
-  // 상세 조회로 표시값/카운트 초기화
-  // 상세 조회로 표시값/카운트 초기화
-  React.useEffect(() => {
-    if (!postId) return;
-    (async () => {
-      try {
-        const raw: any = await postApi.getPostDetail(postId);
-        const d: any = raw?.data?.data ?? raw?.data ?? raw;
-
-        setLikeCount(Number.isFinite(+d.likeCount) ? +d.likeCount : likes);
-        setCommentCount(
-          Number.isFinite(+d.commentCount) ? +d.commentCount : comments
-        );
-        setScrapCnt(
-          Number.isFinite(+d.scrapCount) ? +d.scrapCount : scrapCount
-        );
-
-        setHeaderName(d.authorNickname ?? headerName);
-        setHeaderProfile(d.authorProfileImageUrl ?? headerProfile);
-        setTheDate(formatDateYMD(d.createdAt ?? theDate));
-        setImgs(Array.isArray(d.mediaUrls) ? d.mediaUrls : imgs);
-        setVisibilityState(d.visibility ?? visibilityState);
-
-        // ✅ 좋아요 상태를 서버 값으로 초기화
-        setLiked(!!d.isLiked); // 서버 필드명에 맞게 수정
-      } catch (e) {
-        console.warn("[getPostDetail failed]", e);
-      }
-    })();
-  }, [postId]);
-
-  // 현재 스크랩 여부(아이콘 색칠) 조회
-  React.useEffect(() => {
-    if (!postId) return;
-    (async () => {
-      try {
-        const st = await scrapApi.getScrapStatus(postId);
-        const body = st?.data?.data ?? st?.data ?? {};
-        const preset: number[] =
-          body?.scrapFolderIds ??
-          body?.folderIds ??
-          (Array.isArray(body?.scrapFolders)
-            ? body.scrapFolders.map((f: any) => Number(f?.id))
-            : []) ??
-          [];
-        setScrapped(Array.isArray(preset) && preset.length > 0);
-      } catch {
-        // 조회 실패 시 기본 false 유지
-        setScrapped(false);
-      }
-    })();
-  }, [postId]);
-
   // 삭제
   const handleDelete = async () => {
     if (!confirm("정말 이 게시글을 삭제하시겠습니까?")) return;
     try {
       await postApi.deletePost(postId);
       alert("삭제되었습니다.");
-      onDeleteSuccess ? onDeleteSuccess() : router.back();
+      onDeleteSuccess?.(); // 라우팅은 부모 컴포넌트에서 처리
     } catch (e: any) {
       alert(e?.response?.data?.message || e?.message || "삭제 실패");
     } finally {
@@ -170,56 +109,45 @@ const RecordPost = ({
     }
   };
 
+  // 좋아요 토글
   const toggleLike = async () => {
     if (likeLoading) return;
     setLikeLoading(true);
 
     const was = liked;
-    const id = Number(postId);
 
-    // ✅ 낙관적 반영
     setLiked(!was);
     setLikeCount((c) => (was ? Math.max(0, c - 1) : c + 1));
 
     try {
-      if (was) {
-        await postApi.unlikePost(id);
-      } else {
-        await postApi.likePost(id);
-      }
+      if (was) await postApi.unlikePost(postId);
+      else await postApi.likePost(postId);
     } catch (e: any) {
-      const msg = e?.response?.data?.message || '';
-      const stat = e?.response?.status;
-
-      // “이미 처리됨” 같은 경우는 성공 취급
-      const alreadyProcessed = msg.includes('이미 처리됨') || stat === 409;
-
-      if (!alreadyProcessed) {
-        // ⚠️ 진짜 에러만 롤백
-        setLiked(was);
-        setLikeCount(c => (was ? c + 1 : Math.max(0, c - 1)));
-        alert(msg || e?.message || '좋아요 처리에 실패했습니다.');
-      }
+      setLiked(was);
+      setLikeCount((c) => (was ? c + 1 : Math.max(0, c - 1)));
+      alert(
+        e?.response?.data?.message ||
+          e?.message ||
+          "좋아요 처리에 실패했습니다."
+      );
     } finally {
       setLikeLoading(false);
     }
   };
 
-  // 스크랩 토글은 모달에서 처리. 여기서는 아이콘 색칠만 관리
   const handleScrapSuccess = () => {
     if (!scrapped) {
-      setScrapped(true); // ✅ 색칠
+      setScrapped(true);
       setScrapCnt((c) => c + 1);
     }
     setScrapOpen(false);
   };
-  // 이미지 스크롤
+
   const scrollLeft = () =>
     imageGridRef.current?.scrollBy({ left: -200, behavior: "smooth" });
   const scrollRight = () =>
     imageGridRef.current?.scrollBy({ left: 200, behavior: "smooth" });
 
-  // 이미지 뷰어
   const openImageViewer = (index: number) => {
     if (onImageClick) return onImageClick(index);
     setCurrentImageIndex(index);
@@ -227,7 +155,6 @@ const RecordPost = ({
   };
   const closeImageViewer = () => setIsImageViewerOpen(false);
 
-  // 신고
   const handleReport = async () => {
     if (!reportText.trim()) {
       alert("신고 사유를 입력해주세요.");

--- a/src/components/Search/SearchResult/DeckResult.tsx
+++ b/src/components/Search/SearchResult/DeckResult.tsx
@@ -1,0 +1,88 @@
+import { RightArrow } from "@/assets/icons/RightArrow";
+import { DeckProfile } from "@/components/atoms/DeckProfile";
+import { Text } from "@/components/atoms/Text";
+import { FlexBox } from "@/components/layouts/FlexBox";
+import styled from "styled-components";
+
+interface Artist {
+  id: string;
+  name: string;
+  imageUrl: string;
+}
+
+interface DeckResultProps {
+  artistCount: number;
+  artists: Artist[];
+}
+
+export const DeckResult = ({ artistCount, artists }: DeckResultProps) => {
+  return (
+    <Container>
+      <InfoText>
+        <Text typo="H3" color="primary_800">
+          데크({artistCount})
+        </Text>
+        <div style={{ cursor: "pointer" }}>
+          <FlexBox gap={4}>
+            <Text typo="Body_3" color="primary_800" children="전체보기" />
+            <RightArrow />
+          </FlexBox>
+        </div>
+      </InfoText>
+      <InnerWrapper>
+        <ProfileRow>
+          {artists.slice(0, 7).map((artist) => (
+            <DeckProfile
+              key={artist.id}
+              name={artist.name}
+              imageUrl={artist.imageUrl}
+            />
+          ))}
+        </ProfileRow>
+        {artists.length >= 7 && <MoreOverlay />}
+      </InnerWrapper>
+    </Container>
+  );
+};
+const InfoText = styled.div`
+  display: flex;
+  height: 24px;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const Container = styled.div`
+  display: flex;
+  width: 1200px;
+  padding: 32px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 32px;
+  border-radius: 20px;
+  border: 1px solid var(--Primary-300, #c3dbff);
+  background: var(--Primary-20, #fbfdff);
+  position: relative;
+`;
+
+const InnerWrapper = styled.div`
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  position: relative;
+`;
+
+const ProfileRow = styled.div`
+  display: flex;
+  gap: 16px;
+`;
+
+const MoreOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 80px;
+  height: 176px;
+  background: linear-gradient(90deg, rgba(251, 253, 255, 0) 0%, #fbfdff 91.83%);
+  pointer-events: none;
+`;

--- a/src/components/Search/SearchResult/MyTilePost.tsx
+++ b/src/components/Search/SearchResult/MyTilePost.tsx
@@ -145,6 +145,12 @@ const TimeLineCard = styled.div`
   border-radius: 20px;
   border: 1px solid ${theme.palette.primary_300};
   background: ${theme.palette.gray_0};
+
+  &:hover {
+    background-color: ${theme.palette.primary_100};
+    border-radius: 20px;
+    border: 1.5px solid ${theme.palette.primary_400};
+  }
 `;
 
 const CardContent = styled.div`

--- a/src/components/Search/SearchResult/MyTilePost.tsx
+++ b/src/components/Search/SearchResult/MyTilePost.tsx
@@ -1,0 +1,220 @@
+import { ChatIcon } from "@/assets/icons/ChatIcon";
+import { HeartIcon } from "@/assets/icons/HeartIcon";
+import { MoveRightIcon } from "@/assets/icons/MoveRightIcon";
+import { Text } from "@/components/atoms/Text";
+import { FlexBox } from "@/components/layouts/FlexBox";
+import { SearchPost } from "@/model/components/SearchType";
+import { theme } from "@/styles/theme";
+import { useEffect } from "react";
+import styled from "styled-components";
+
+interface MyTilePostProps {
+  posts: SearchPost[];
+}
+
+export const MyTilePost = ({ posts }: MyTilePostProps) => {
+  const formatDate = (isoDate: string) => {
+    const date = new Date(isoDate);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+
+    return `${year}.${month.toString().padStart(2, "0")}.${day
+      .toString()
+      .padStart(2, "0")}`;
+  };
+
+  return (
+    <Wrapper>
+      <TimeLineWrap>
+        {posts.map((post) => {
+          const hasimage = !!post.mainImageUrl;
+          return (
+            <TimeLineCard key={post.postId}>
+              <CardContent>
+                <FlexBox gap={10}>
+                  {post.authorProfileImageUrl && (
+                    <ProfileImage
+                      src={post.authorProfileImageUrl}
+                      alt="게시물 작성자 프로필 이미지"
+                    />
+                  )}
+
+                  <TitleWrap>
+                    <Text typo="Body_3">{post.authorNickname}</Text>
+                  </TitleWrap>
+                </FlexBox>
+                <Text
+                  typo="Body_3"
+                  color="gray_700"
+                  children={formatDate(post.createdAt)}
+                />
+              </CardContent>
+              <TitleWrap>
+                <Text typo="H4">{post.title}</Text>
+              </TitleWrap>
+              <PostContent>
+                <Wrap $hasImage={hasimage}>
+                  <Text typo="Body_3">{post.content}</Text>
+                </Wrap>
+                {post.mainImageUrl && (
+                  <Image src={post.mainImageUrl} alt="게시물 이미지" />
+                )}
+              </PostContent>
+              <DetailWrap>
+                <IconWrapper>
+                  <IconDiv>
+                    <HeartIcon />
+                    <Text
+                      typo="Body_3"
+                      children={post.likeCount}
+                      color="Heart"
+                    />
+                  </IconDiv>
+                  <IconDiv>
+                    <ChatIcon />
+                    <Text
+                      typo="Body_3"
+                      children={post.commentCount}
+                      color="primary_500"
+                    />
+                  </IconDiv>
+                </IconWrapper>
+
+                <ViewButton
+                  onClick={() =>
+                    (window.location.href = `/record-post/${post.postId}`)
+                  }
+                >
+                  <Text
+                    color="primary_700"
+                    typo="Caption_2"
+                    children="원글보기"
+                  />
+                  <MoveRightIcon size={20} />
+                </ViewButton>
+              </DetailWrap>
+            </TimeLineCard>
+          );
+        })}
+      </TimeLineWrap>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  width: 100%;
+`;
+
+const ProfileImage = styled.img`
+  width: 32px;
+  height: 32px;
+  aspect-ratio: 1/1;
+  border-radius: 16px;
+`;
+
+const TimeLineWrap = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const TimeLineCard = styled.div`
+  display: flex;
+  width: 467px;
+  height: 320px;
+  padding: 24px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  border-radius: 20px;
+  border: 1px solid ${theme.palette.primary_300};
+  background: ${theme.palette.gray_0};
+`;
+
+const CardContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  margin-bottom: 8px;
+`;
+
+const PostContent = styled.div`
+  display: flex;
+  height: 146px;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const Image = styled.img`
+  display: flex;
+  width: 168px;
+  height: 142px;
+  justify-content: flex-end;
+  align-items: center;
+  border-radius: 16px;
+  border: 1px solid var(--Primary-200, #e6f0ff);
+  background: var(--Gray-0, #fff);
+  box-shadow: 0 4px 12px 0 rgba(159, 198, 255, 0.25);
+  object-fit: cover;
+`;
+
+const TitleWrap = styled.div`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  color: var(--Gray-1000, #000);
+  text-overflow: ellipsis;
+
+  /* Body 3 */
+  font-family: Pretendard;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%;
+`;
+
+const Wrap = styled.div<{ $hasImage: boolean }>`
+  height: ${({ $hasImage }) => ($hasImage ? "72px" : "312px")};
+  width: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: ${({ $hasImage }) => ($hasImage ? 3 : 13)};
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+`;
+
+const DetailWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  margin-top: -4px;
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const IconDiv = styled.div`
+  display: flex;
+  width: 100%;
+  height: 26px;
+  align-items: center;
+  gap: 4px;
+`;
+
+const ViewButton = styled.button`
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: ${theme.palette.primary_700};
+`;

--- a/src/components/Search/SearchResult/MyTilePost.tsx
+++ b/src/components/Search/SearchResult/MyTilePost.tsx
@@ -5,14 +5,14 @@ import { Text } from "@/components/atoms/Text";
 import { FlexBox } from "@/components/layouts/FlexBox";
 import { SearchPost } from "@/model/components/SearchType";
 import { theme } from "@/styles/theme";
-import { useEffect } from "react";
 import styled from "styled-components";
 
 interface MyTilePostProps {
   posts: SearchPost[];
+  highlightWord?: string;
 }
 
-export const MyTilePost = ({ posts }: MyTilePostProps) => {
+export const MyTilePost = ({ posts, highlightWord }: MyTilePostProps) => {
   const formatDate = (isoDate: string) => {
     const date = new Date(isoDate);
     const year = date.getFullYear();
@@ -22,6 +22,19 @@ export const MyTilePost = ({ posts }: MyTilePostProps) => {
     return `${year}.${month.toString().padStart(2, "0")}.${day
       .toString()
       .padStart(2, "0")}`;
+  };
+
+  const highlightText = (text: string, word?: string) => {
+    if (!word) return text;
+    const regex = new RegExp(`(${word})`, "gi");
+    const parts = text.split(regex);
+    return parts.map((part, idx) =>
+      part.toLowerCase() === word.toLowerCase() ? (
+        <Highlight key={idx}>{part}</Highlight>
+      ) : (
+        part
+      )
+    );
   };
 
   return (
@@ -39,7 +52,6 @@ export const MyTilePost = ({ posts }: MyTilePostProps) => {
                       alt="게시물 작성자 프로필 이미지"
                     />
                   )}
-
                   <TitleWrap>
                     <Text typo="Body_3">{post.authorNickname}</Text>
                   </TitleWrap>
@@ -51,11 +63,15 @@ export const MyTilePost = ({ posts }: MyTilePostProps) => {
                 />
               </CardContent>
               <TitleWrap>
-                <Text typo="H4">{post.title}</Text>
+                <Text typo="H4">
+                  {highlightText(post.title, highlightWord)}
+                </Text>
               </TitleWrap>
               <PostContent>
                 <Wrap $hasImage={hasimage}>
-                  <Text typo="Body_3">{post.content}</Text>
+                  <Text typo="Body_3">
+                    {highlightText(post.content, highlightWord)}
+                  </Text>
                 </Wrap>
                 {post.mainImageUrl && (
                   <Image src={post.mainImageUrl} alt="게시물 이미지" />
@@ -80,7 +96,6 @@ export const MyTilePost = ({ posts }: MyTilePostProps) => {
                     />
                   </IconDiv>
                 </IconWrapper>
-
                 <ViewButton
                   onClick={() =>
                     (window.location.href = `/record-post/${post.postId}`)
@@ -217,4 +232,8 @@ const ViewButton = styled.button`
   justify-content: center;
   cursor: pointer;
   color: ${theme.palette.primary_700};
+`;
+
+const Highlight = styled.span`
+  color: ${theme.palette.primary_600};
 `;

--- a/src/components/Search/SearchResult/MyTileResult.tsx
+++ b/src/components/Search/SearchResult/MyTileResult.tsx
@@ -1,0 +1,86 @@
+import { MyTilePost } from "./MyTilePost";
+import { SearchPost } from "@/model/components/SearchType";
+import styled from "styled-components";
+import { theme } from "@/styles/theme";
+import { Text } from "@/components/atoms/Text";
+import { FlexBox } from "@/components/layouts/FlexBox";
+import { RightArrow } from "./../../../assets/icons/RightArrow";
+
+interface MyTileResultProps {
+  posts: SearchPost[];
+  postCount: number;
+}
+
+export const MyTileResult = ({ posts, postCount }: MyTileResultProps) => {
+  const displayPosts = posts.slice(0, 3);
+  const showOverlay = posts.length >= 3;
+
+  return (
+    <Container>
+      <InfoText>
+        <Text typo="H3" color="primary_800">
+          마이타일({postCount})
+        </Text>
+        <div style={{ cursor: "pointer" }}>
+          <FlexBox gap={4}>
+            <Text typo="Body_3" color="primary_800" children="전체보기" />
+            <RightArrow />
+          </FlexBox>
+        </div>
+      </InfoText>
+      <InnerWrapper>
+        <ProfileRow>
+          <MyTilePost posts={displayPosts} />
+        </ProfileRow>
+        {showOverlay && <MoreOverlay />}
+      </InnerWrapper>
+    </Container>
+  );
+};
+
+const InfoText = styled.div`
+  display: flex;
+  height: 24px;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const Container = styled.div`
+  display: flex;
+  width: 1200px;
+  padding: 32px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 32px;
+  border-radius: 20px;
+  border: 1px solid var(--Primary-300, #c3dbff);
+  background: var(--Primary-20, #fbfdff);
+  position: relative;
+`;
+
+const InnerWrapper = styled.div`
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  position: relative;
+`;
+
+const ProfileRow = styled.div`
+  display: flex;
+  gap: 16px;
+`;
+
+const MoreOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 80px;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    rgba(251, 253, 255, 0) 0%,
+    ${theme.palette.primary_20} 91.83%
+  );
+  pointer-events: none;
+`;

--- a/src/components/Search/SearchResult/MyTileResult.tsx
+++ b/src/components/Search/SearchResult/MyTileResult.tsx
@@ -9,9 +9,14 @@ import { RightArrow } from "./../../../assets/icons/RightArrow";
 interface MyTileResultProps {
   posts: SearchPost[];
   postCount: number;
+  highlightWord?: string;
 }
 
-export const MyTileResult = ({ posts, postCount }: MyTileResultProps) => {
+export const MyTileResult = ({
+  posts,
+  postCount,
+  highlightWord,
+}: MyTileResultProps) => {
   const displayPosts = posts.slice(0, 3);
   const showOverlay = posts.length >= 3;
 
@@ -30,7 +35,7 @@ export const MyTileResult = ({ posts, postCount }: MyTileResultProps) => {
       </InfoText>
       <InnerWrapper>
         <ProfileRow>
-          <MyTilePost posts={displayPosts} />
+          <MyTilePost posts={displayPosts} highlightWord={highlightWord} />
         </ProfileRow>
         {showOverlay && <MoreOverlay />}
       </InnerWrapper>

--- a/src/components/Search/SearchResult/SearchHeader.tsx
+++ b/src/components/Search/SearchResult/SearchHeader.tsx
@@ -1,0 +1,50 @@
+import { Text } from "@/components/atoms/Text";
+import { theme } from "@/styles/theme";
+import styled from "styled-components";
+
+interface SearchHeaderProps {
+  searchCount: number;
+}
+
+export const SearchHeader = ({ searchCount }: SearchHeaderProps) => {
+  return (
+    <Container>
+      <ResultText>
+        <Text typo="H5" children="전체 검색 결과" />
+      </ResultText>
+      <SearchResultText>
+        <Text typo="Body_1" color="primary_600" children={searchCount} />
+        <Text
+          typo="Body_3"
+          color="gray_800"
+          children="건의 검색 결과가 있습니다."
+        />
+      </SearchResultText>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const ResultText = styled.div`
+  display: flex;
+  height: 48px;
+  padding: 11px 12px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+const SearchResultText = styled.div`
+  display: flex;
+  width: 1046px;
+  height: 48px;
+  padding: 9px 16px;
+  align-items: center;
+  border-radius: 10px;
+  background: ${theme.palette.gray_50};
+`;

--- a/src/components/Search/SearchResult/TimeTileResult.tsx
+++ b/src/components/Search/SearchResult/TimeTileResult.tsx
@@ -1,0 +1,73 @@
+import { RightArrow } from "@/assets/icons/RightArrow";
+import { Text } from "@/components/atoms/Text";
+import { TimeTileCard } from "@/components/atoms/TimeTileCard";
+import { FlexBox } from "@/components/layouts/FlexBox";
+import { SearchEvent } from "@/model/components/SearchType";
+import styled from "styled-components";
+
+interface TimeTileResultProps {
+  eventCount: number;
+  events: SearchEvent[];
+  highlightWord?: string;
+}
+
+export const TimeTileResult = ({
+  eventCount,
+  events,
+  highlightWord,
+}: TimeTileResultProps) => {
+  const displayEvents = events.slice(0, 5);
+
+  return (
+    <Container>
+      <InfoText>
+        <Text typo="H3" color="primary_800">
+          타임타일({eventCount})
+        </Text>
+        <div style={{ cursor: "pointer" }}>
+          <FlexBox gap={4}>
+            <Text typo="Body_3" color="primary_800" children="전체보기" />
+            <RightArrow />
+          </FlexBox>
+        </div>
+      </InfoText>
+      <Wrapper>
+        {displayEvents.map((event) => (
+          <TimeTileCard
+            key={event.groupId}
+            event={event}
+            highlightWord={highlightWord}
+          />
+        ))}
+      </Wrapper>
+    </Container>
+  );
+};
+
+const InfoText = styled.div`
+  display: flex;
+  height: 24px;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const Container = styled.div`
+  display: flex;
+  padding: 32px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 32px;
+  align-self: stretch;
+  border-radius: 20px;
+  border: 1px solid var(--Primary-300, #c3dbff);
+  background: var(--Primary-20, #fbfdff);
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  align-self: stretch;
+`;

--- a/src/components/Search/SearchResult/UserResult.tsx
+++ b/src/components/Search/SearchResult/UserResult.tsx
@@ -1,0 +1,89 @@
+import { RightArrow } from "@/assets/icons/RightArrow";
+import { Text } from "@/components/atoms/Text";
+import { UserProfileCard } from "@/components/atoms/UserProfileCard";
+import { FlexBox } from "@/components/layouts/FlexBox";
+import styled from "styled-components";
+
+interface User {
+  nickname: string;
+  imageUrl: string;
+  introduction: string | null;
+}
+
+interface UserResultProps {
+  userCount: number;
+  users: User[];
+}
+
+export const UserResult = ({ userCount, users }: UserResultProps) => {
+  return (
+    <Container>
+      <InfoText>
+        <Text typo="H3" color="primary_800">
+          유저({userCount})
+        </Text>
+        <div style={{ cursor: "pointer" }}>
+          <FlexBox gap={4}>
+            <Text typo="Body_3" color="primary_800" children="전체보기" />
+            <RightArrow />
+          </FlexBox>
+        </div>
+      </InfoText>
+      <InnerWrapper>
+        <ProfileRow>
+          {users.slice(0, 5).map((user, index) => (
+            <UserProfileCard
+              key={index}
+              name={user.nickname}
+              imageUrl={user.imageUrl}
+              introduction={user.introduction}
+            />
+          ))}
+        </ProfileRow>
+        {users.length >= 5 && <MoreOverlay />}
+      </InnerWrapper>
+    </Container>
+  );
+};
+const InfoText = styled.div`
+  display: flex;
+  height: 24px;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const Container = styled.div`
+  display: flex;
+  width: 1200px;
+  padding: 32px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 32px;
+  border-radius: 20px;
+  border: 1px solid var(--Primary-300, #c3dbff);
+  background: var(--Primary-20, #fbfdff);
+  position: relative;
+`;
+
+const InnerWrapper = styled.div`
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  position: relative;
+`;
+
+const ProfileRow = styled.div`
+  display: flex;
+  gap: 16px;
+`;
+
+const MoreOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 80px;
+  height: 176px;
+  background: linear-gradient(90deg, rgba(251, 253, 255, 0) 0%, #fbfdff 91.83%);
+  pointer-events: none;
+`;

--- a/src/components/Timeline/TileCard/TileCard.stories.ts
+++ b/src/components/Timeline/TileCard/TileCard.stories.ts
@@ -1,62 +1,53 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { TileCard } from './index'
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { TileCard } from "./index";
 
 const meta: Meta<typeof TileCard> = {
-  title: 'Components/TileCard',
+  title: "Components/TileCard",
   component: TileCard,
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   parameters: {
-    layout: 'centered',
+    layout: "centered",
   },
-}
+};
 
-export default meta
-type Story = StoryObj<typeof TileCard>
+export default meta;
+type Story = StoryObj<typeof TileCard>;
 
 const mockSchedules = [
   {
-    title: '싱글 <Spicy> 발매',
-    date: '2025.08.23',
-    tags: ['tile', 'deck'] as ('tile' | 'deck' | 'song')[],
-    description: '어쩌구저쩌구 스케쥴 설명어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 스케쥴 설명 .',
-    thumbnails: ['/images/thumb1.jpg', '/images/thumb2.jpg'],
-    thumbnailLabels: ['썸네일 텍스트 썸네일 텍스트 썸네일 텍스트 썸네일 텍스트 '],
+    title: "싱글 <Spicy> 발매",
+    date: "2025.08.23",
+    tags: ["tile", "deck"] as ("tile" | "deck" | "song")[],
+    relatedEvents: [{ name: "팬미팅 개최" }, { name: "쇼케이스" }],
+    relatedArtists: [{ name: "NewJeans" }, { name: "aespa" }],
+    description:
+      "어쩌구저쩌구 스케쥴 설명어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 스케쥴 설명 어쩌구저쩌구 스케쥴 설명 .",
+    thumbnails: ["/images/thumb1.jpg", "/images/thumb2.jpg"],
+    thumbnailLabels: [
+      "썸네일 텍스트 썸네일 텍스트 썸네일 텍스트 썸네일 텍스트 ",
+    ],
     participants: 123,
   },
   {
-    title: '팬미팅 개최',
-    date: '2025.08.23',
-    tags: ['deck'] as ('tile' | 'deck' | 'song')[],
-    description: '서울 올림픽홀에서 팬들과 만나는 자리입니다.',
-    thumbnails: ['/images/thumb3.jpg'],
-    thumbnailLabels: ['뮤직비디오 촬영', '자켓 사진 촬영'],
-    participants: 456,
-  },
-  {
-    title: '뮤직비디오 공개',
-    date: '2025.08.23',
-    tags: ['song'] as ('tile' | 'deck' | 'song')[],
-    description: '타이틀곡 뮤직비디오가 공식 유튜브 채널에 공개됩니다.',
-    thumbnails: ['/images/thumb4.jpg', '/images/thumb5.jpg'],
-    thumbnailLabels: ['뮤직비디오 촬영', '자켓 사진 촬영'],
+    title: "뮤직비디오 공개",
+    date: "2025.08.23",
+    tags: ["song"] as ("tile" | "deck" | "song")[],
+    relatedEvents: [{ name: "촬영 현장" }],
+    relatedArtists: [{ name: "NewJeans" }],
+    description: "타이틀곡 뮤직비디오가 공식 유튜브 채널에 공개됩니다.",
+    thumbnails: ["/images/thumb4.jpg", "/images/thumb5.jpg"],
+    thumbnailLabels: ["뮤직비디오 촬영", "자켓 사진 촬영"],
     participants: 789,
   },
   {
-    title: '음악 방송 첫 무대',
-    date: '2025.08.23',
-    tags: ['song', 'deck'] as ('tile' | 'deck' | 'song')[],
-    description: '뮤직뱅크에서 첫 컴백 무대를 가집니다.',
-    thumbnails: ['/images/thumb6.jpg'],
-    thumbnailLabels: ['뮤직비디오 촬영', '자켓 사진 촬영'],
-    participants: 321,
-  },
-  {
-    title: '해외 투어 일정 발표',
-    date: '2025.08.23',
-    tags: ['tile'] as ('tile' | 'deck' | 'song')[],
-    description: '일본, 미국, 유럽 등지의 투어 일정이 발표됩니다.',
-    thumbnails: ['/images/thumb7.jpg'],
-    thumbnailLabels: ['뮤직비디오 촬영', '자켓 사진 촬영'],
+    title: "해외 투어 일정 발표",
+    date: "2025.08.23",
+    tags: ["tile", "deck"] as ("tile" | "deck" | "song")[],
+    relatedEvents: [{ name: "일본 투어" }, { name: "미국 투어" }],
+    relatedArtists: [{ name: "aespa" }],
+    description: "일본, 미국, 유럽 등지의 투어 일정이 발표됩니다.",
+    thumbnails: ["/images/thumb7.jpg"],
+    thumbnailLabels: ["뮤직비디오 촬영", "자켓 사진 촬영"],
     participants: 890,
   },
 ];
@@ -66,11 +57,11 @@ export const Default: Story = {
     selected: false,
     schedules: mockSchedules,
   },
-}
+};
 
 export const Selected: Story = {
   args: {
     selected: true,
     schedules: mockSchedules,
   },
-}
+};

--- a/src/components/Timeline/TileCard/index.tsx
+++ b/src/components/Timeline/TileCard/index.tsx
@@ -1,7 +1,7 @@
-import styled from 'styled-components';
-import { theme } from '@/styles/theme';
-import { Text } from '@/components/atoms/Text';
-import { Tag } from '@/components/atoms/Tag';
+import styled from "styled-components";
+import { theme } from "@/styles/theme";
+import { Text } from "@/components/atoms/Text";
+import { Tag } from "@/components/atoms/Tag";
 interface TileCardProps {
   selected?: boolean;
   schedules: Schedule[];
@@ -9,7 +9,9 @@ interface TileCardProps {
 interface Schedule {
   title: string;
   date: string;
-  tags: ('tile' | 'deck' | 'song')[];
+  tags: ("tile" | "deck" | "song")[];
+  relatedEvents?: { name: string }[];
+  relatedArtists?: { name: string }[];
   description: string;
   thumbnails: string[];
   thumbnailLabels: string[];
@@ -17,7 +19,7 @@ interface Schedule {
 }
 
 const getDayFromDate = (date: string) => {
-  const day = date.split('.')[2];
+  const day = date.split(".")[2];
   return `${parseInt(day, 10)}일`;
 };
 
@@ -36,8 +38,8 @@ export const TileCard = ({ selected = false, schedules }: TileCardProps) => {
 const CollapsedContent = ({ schedules }: { schedules: Schedule[] }) => {
   const titles = schedules
     .slice(0, 2)
-    .map(s => s.title)
-    .join(', ');
+    .map((s) => s.title)
+    .join(", ");
 
   return (
     <>
@@ -76,13 +78,14 @@ const ExpandedContent = ({ schedules }: { schedules: Schedule[] }) => {
           {schedule.title}
         </Text>
       </Header>
-
       <TagWrapper>
-        {schedule.tags.map((tag, i) => (
-          <Tag key={i} variant={tag} />
+        {schedule.relatedEvents?.map((event, i) => (
+          <Tag key={`event-${i}`} variant="tile" children={event.name} />
+        ))}
+        {schedule.relatedArtists?.map((artist, i) => (
+          <Tag key={`artist-${i}`} variant="deck" children={artist.name} />
         ))}
       </TagWrapper>
-
       <TextWrapper>
         <Text typo="Body_3" color="gray_1000">
           {schedule.description}
@@ -109,7 +112,7 @@ const ExpandedContent = ({ schedules }: { schedules: Schedule[] }) => {
 const CardWrapper = styled.div<{ selected: boolean }>`
   display: flex;
   width: 818px;
-  padding: ${({ selected }) => (selected ? '24px 24px 16px 24px' : '24px')};
+  padding: ${({ selected }) => (selected ? "24px 24px 16px 24px" : "24px")};
   flex-direction: column;
   align-items: flex-start;
   gap: 24px;

--- a/src/components/atoms/DeckProfile/DeckProfile.stories.ts
+++ b/src/components/atoms/DeckProfile/DeckProfile.stories.ts
@@ -1,0 +1,30 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { DeckProfile } from ".";
+
+const meta = {
+  title: "Atom/DeckProfile",
+  component: DeckProfile,
+  tags: ["autodocs"],
+  parameters: {
+    componentSubtitle: "DeckProfile 컴포넌트",
+    docs: {
+      description: {
+        component: `
+- 아티스트(덱) 프로필 컴포넌트입니다.
+- name은 아티스트 이름입니다.
+- imageUrl은 아티스트 프로필이미지입니다.
+`,
+      },
+    },
+  },
+} satisfies Meta<typeof DeckProfile>;
+
+export default meta;
+type Story = StoryObj<typeof DeckProfile>;
+
+export const DefaultDeckProfile: Story = {
+  args: {
+    name: "레드벨벳",
+    imageUrl: "/record-image.png",
+  },
+};

--- a/src/components/atoms/DeckProfile/index.tsx
+++ b/src/components/atoms/DeckProfile/index.tsx
@@ -1,0 +1,79 @@
+import { theme } from "@/styles/theme";
+import styled from "styled-components";
+
+interface DeckProfileProps {
+  name: string;
+  imageUrl: string;
+}
+
+export const DeckProfile = ({ name, imageUrl }: DeckProfileProps) => {
+  return (
+    <Container>
+      <Wrapper>
+        <ArtistImage src={imageUrl} alt="profile" />
+        <ArtistName>
+          <NameText>{name}</NameText>
+        </ArtistName>
+      </Wrapper>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: inline-flex;
+  padding: 16px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  border-radius: 20px;
+  border: 1.5px solid ${theme.palette.primary_300};
+  background: ${theme.palette.primary_100};
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  align-self: stretch;
+`;
+
+const ArtistImage = styled.img`
+  width: 80px;
+  height: 80px;
+  aspect-ratio: 1/1;
+  border-radius: 100px;
+  box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.2);
+`;
+
+const ArtistName = styled.div`
+  display: flex;
+  width: 120px;
+  height: 52px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+const NameText = styled.div`
+  display: -webkit-box;
+  width: 120px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  color: ${theme.palette.primary_800};
+  text-align: center;
+  text-overflow: ellipsis;
+
+  /* H4-3 */
+  font-family: Pretendard-Medium;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 130%;
+`;

--- a/src/components/atoms/Tag/Tag.stories.ts
+++ b/src/components/atoms/Tag/Tag.stories.ts
@@ -10,7 +10,8 @@ const meta: Meta<typeof Tag> = {
     docs: {
       description: {
         component: `
-- variant 값으로 "tile" | "deck" | "song" 중 하나를 선택할 수 있습니다.`,
+- variant 값으로 "tile" | "deck" | "song" 중 하나를 선택할 수 있습니다.
+- children으로 태그에 표시할 텍스트를 전달합니다.`,
       },
     },
   },
@@ -19,6 +20,10 @@ const meta: Meta<typeof Tag> = {
       control: "select",
       options: ["tile", "deck", "song"],
       description: "Tag 종류",
+    },
+    children: {
+      control: "text",
+      description: "태그에 표시할 텍스트",
     },
   },
 };
@@ -29,17 +34,20 @@ type Story = StoryObj<typeof Tag>;
 export const TileTag: Story = {
   args: {
     variant: "tile",
+    children: "250913 뮤직뱅크",
   },
 };
 
 export const DeckTag: Story = {
   args: {
     variant: "deck",
+    children: "NewJeans",
   },
 };
 
 export const SongTag: Story = {
   args: {
     variant: "song",
+    children: "좋은 노래",
   },
 };

--- a/src/components/atoms/Tag/index.tsx
+++ b/src/components/atoms/Tag/index.tsx
@@ -12,9 +12,6 @@ interface PropsType {
 }
 
 export const Tag = ({ variant, onClick, children, ...props }: PropsType) => {
-  const tagChildren =
-    variant === "tile" ? "타일" : variant === "deck" ? "데크" : "";
-
   const renderTag = () => {
     if (variant === "song") {
       return (
@@ -27,7 +24,7 @@ export const Tag = ({ variant, onClick, children, ...props }: PropsType) => {
     return (
       <FlexBox>
         <StyledTag variant={variant}>
-          <Text typo="Caption_1">관련{tagChildren}</Text>
+          <Text typo="Caption_1">{children}</Text>
         </StyledTag>
       </FlexBox>
     );

--- a/src/components/atoms/TimeTileCard/TimeTileCard.stories.ts
+++ b/src/components/atoms/TimeTileCard/TimeTileCard.stories.ts
@@ -1,0 +1,37 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { TimeTileCard } from ".";
+
+const meta = {
+  title: "Atom/TimeTileCard",
+  component: TimeTileCard,
+  tags: ["autodocs"],
+  parameters: {
+    componentSubtitle: "TimeTileCard 컴포넌트",
+    docs: {
+      description: {
+        component: `
+- 타임타일 카드 컴포넌트입니다.
+`,
+      },
+    },
+  },
+} satisfies Meta<typeof TimeTileCard>;
+
+export default meta;
+type Story = StoryObj<typeof TimeTileCard>;
+
+export const DefaultTimeTileCard: Story = {
+  args: {
+    event: {
+      groupId: "1",
+      name: "Prem Customer Division Associate",
+      activityTypes: ["콘서트/팬미팅"],
+      artistImageUrl:
+        "https://i.scdn.co/image/ab6761610000e5eb80668ba2b15094d083780ea9",
+      artistName: "NewJeans",
+      description:
+        "Provident delinquo tener curiositas volva caecus tracto denego.",
+      startedAt: "2025-04-11",
+    },
+  },
+};

--- a/src/components/atoms/TimeTileCard/index.tsx
+++ b/src/components/atoms/TimeTileCard/index.tsx
@@ -1,0 +1,204 @@
+import { SearchEvent } from "@/model/components/SearchType";
+import { Tag } from "@/components/atoms/Tag";
+import styled from "styled-components";
+import { Text } from "../Text";
+import { TagCategory } from "../TagCategory";
+import { TagCategoryName } from "@/model/common/tagcategory";
+import { theme } from "@/styles/theme";
+
+interface TimeTileCardProps {
+  event: SearchEvent;
+  highlightWord?: string;
+}
+
+export const TimeTileCard = ({ event, highlightWord }: TimeTileCardProps) => {
+  const formatDate = (dateString: string) => {
+    const [year, month, day] = dateString.split("-");
+    return `${year.slice(2)}/${month}/${day}`;
+  };
+
+  const highlightText = (text: string, word?: string) => {
+    if (!word) return text;
+    const regex = new RegExp(`(${word})`, "gi");
+    const parts = text.split(regex);
+    return parts.map((part, idx) =>
+      part.toLowerCase() === word.toLowerCase() ? (
+        <Highlight key={idx}>{part}</Highlight>
+      ) : (
+        part
+      )
+    );
+  };
+
+  return (
+    <Container>
+      <ArtistWrapper>
+        <ArtistDiv>
+          <ArtistProfile src={event.artistImageUrl} alt="아티스트 프로필사진" />
+          <TextWrapper>
+            <TextDiv>
+              <Text typo="H4_3" color="primary_800">
+                {event.artistName}
+              </Text>
+            </TextDiv>
+          </TextWrapper>
+        </ArtistDiv>
+      </ArtistWrapper>
+      <TileWrapper>
+        <TileDiv>
+          <TopWrapper>
+            <Text
+              typo="Body_1"
+              color="gray_700"
+              children={formatDate(event.startedAt)}
+            />
+            <Text typo="H4">{highlightText(event.name, highlightWord)}</Text>
+          </TopWrapper>
+          <TagWrapper>
+            {event.activityTypes.map((category, idx) => (
+              <TagCategory
+                key={`cat-${idx}`}
+                category={category as TagCategoryName}
+              />
+            ))}
+            {event.relatedArtists?.map((artist, idx) => (
+              <Tag key={`artist-${idx}`} variant="deck">
+                {artist.name}
+              </Tag>
+            ))}
+            {event.relatedEvents?.map((ev, idx) => (
+              <Tag key={`event-${idx}`} variant="tile">
+                {ev.name}
+              </Tag>
+            ))}
+          </TagWrapper>
+          <DescWrapper>
+            <Text typo="Body_3">
+              {highlightText(event.description, highlightWord)}
+            </Text>
+          </DescWrapper>
+        </TileDiv>
+      </TileWrapper>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  width: 1136px;
+  align-items: center;
+  gap: -1px;
+`;
+
+const ArtistWrapper = styled.div`
+  display: flex;
+  width: 136px;
+  padding: 16px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  flex-shrink: 0;
+  border-radius: 20px;
+  border: 1.5px solid var(--Primary-300, #c3dbff);
+  background: var(--Primary-100, #f2f7ff);
+`;
+
+const ArtistDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  align-self: stretch;
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 88px;
+  height: 52px;
+`;
+
+const TextDiv = styled.div`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+`;
+
+const ArtistProfile = styled.img`
+  width: 80px;
+  height: 80px;
+  aspect-ratio: 1/1;
+  border-radius: 100px;
+  box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.2);
+`;
+
+const TileWrapper = styled.div`
+  display: flex;
+  width: 1000px;
+  height: 176px;
+  padding: 24px;
+  flex-direction: column;
+  align-items: flex-start;
+  flex-shrink: 0;
+  border-radius: 16px;
+  border: 1px solid var(--Primary-300, #c3dbff);
+  background: var(--Gray-0, #fff);
+
+  &:hover {
+    border-radius: 16px;
+    border: 1px solid var(--Primary-300, #c3dbff);
+    background: var(--Primary-100, #f2f7ff);
+  }
+`;
+
+const TileDiv = styled.div`
+  display: flex;
+  width: 952px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 18px;
+`;
+
+const TopWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  align-self: stretch;
+`;
+
+const TagWrapper = styled.div`
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+  & > * {
+    flex-shrink: 0;
+  }
+
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE 10+ */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+  }
+`;
+
+const DescWrapper = styled.div`
+  height: 48px;
+  align-self: stretch;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Highlight = styled.span`
+  color: ${theme.palette.primary_600};
+`;

--- a/src/components/atoms/UserProfileCard/UserProfileCard.stories.ts
+++ b/src/components/atoms/UserProfileCard/UserProfileCard.stories.ts
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { UserProfileCard } from ".";
+
+const meta = {
+  title: "Atom/UserProfileCard",
+  component: UserProfileCard,
+  tags: ["autodocs"],
+  parameters: {
+    componentSubtitle: "UserProfileCard 컴포넌트",
+    docs: {
+      description: {
+        component: `
+- 유저 프로필 컴포넌트입니다.
+- name은 유저 이름입니다.
+- imageUrl은 유저 프로필이미지입니다.
+- introduction은 유저 한줄소개입니다.
+`,
+      },
+    },
+  },
+} satisfies Meta<typeof UserProfileCard>;
+
+export default meta;
+type Story = StoryObj<typeof UserProfileCard>;
+
+export const DefaultUserProfileCard: Story = {
+  args: {
+    name: "닝닝닝닝닝닝",
+    imageUrl: "/record-image.png",
+    introduction:
+      "닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝닝",
+  },
+};

--- a/src/components/atoms/UserProfileCard/index.tsx
+++ b/src/components/atoms/UserProfileCard/index.tsx
@@ -1,0 +1,102 @@
+import { theme } from "@/styles/theme";
+import styled from "styled-components";
+import { Text } from "../Text";
+
+interface UserProfileProps {
+  name: string;
+  imageUrl: string;
+  introduction: string | null;
+}
+
+export const UserProfileCard = ({
+  name,
+  imageUrl,
+  introduction,
+}: UserProfileProps) => {
+  return (
+    <Container>
+      <Wrapper>
+        <ImageDiv>
+          <UserImage src={imageUrl} alt="profile" />
+        </ImageDiv>
+        <UserDiv>
+          <UserName>
+            <NameText>{name}</NameText>
+          </UserName>
+          <Text typo="Caption_2" color="gray_600" children={introduction} />
+        </UserDiv>
+      </Wrapper>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  width: 216px;
+  height: 176px;
+  padding: 16px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  flex-shrink: 0;
+  border-radius: 20px;
+  border: 1.5px solid ${theme.palette.primary_300};
+  background: ${theme.palette.gray_0};
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  align-self: stretch;
+`;
+
+const ImageDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: stretch;
+`;
+
+const UserImage = styled.img`
+  width: 56px;
+  height: 56px;
+  aspect-ratio: 1/1;
+  aspect-ratio: 1/1;
+  border-radius: 100px;
+  box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.2);
+`;
+
+const UserDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  align-self: stretch;
+`;
+
+const UserName = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const NameText = styled.div`
+  display: -webkit-box;
+  width: 184px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  color: ${theme.palette.gray_1000};
+  text-align: center;
+  text-overflow: ellipsis;
+
+  /* H4-3 */
+  font-family: Pretendard-Medium;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 130%;
+`;

--- a/src/model/components/SearchType.ts
+++ b/src/model/components/SearchType.ts
@@ -1,3 +1,14 @@
+export interface RelatedArtist {
+  id: string;
+  name: string;
+  imageUrl: string;
+}
+
+export interface RelatedEvent {
+  groupId: string;
+  name: string;
+}
+
 export interface SearchPost {
   postId: number;
   groupId: string;
@@ -20,6 +31,8 @@ export interface SearchEvent {
   artistName: string;
   description: string;
   startedAt: string;
+  relatedArtists?: RelatedArtist[];
+  relatedEvents?: RelatedEvent[];
 }
 
 export interface SearchResponse {

--- a/src/model/components/SearchType.ts
+++ b/src/model/components/SearchType.ts
@@ -32,3 +32,15 @@ export interface SearchResponse {
   eventCount: number;
   events: Event[];
 }
+
+export interface SearchArtist {
+  id: string;
+  name: string;
+  imageUrl: string;
+}
+
+export interface SearchUser {
+  nickname: string;
+  introduction: string | null;
+  imageUrl: string;
+}

--- a/src/model/components/SearchType.ts
+++ b/src/model/components/SearchType.ts
@@ -24,13 +24,13 @@ export interface SearchEvent {
 
 export interface SearchResponse {
   artistCount: number;
-  artists: string[];
+  artists: SearchArtist[];
   userCount: number;
-  users: string[];
+  users: SearchUser[];
   postCount: number;
   posts: SearchPost[];
   eventCount: number;
-  events: Event[];
+  events: SearchEvent[];
 }
 
 export interface SearchArtist {


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
전체 검색 페이지 UI를 구성하고 기능 연결해두었습니다.

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
전체 검색 페이지 (검색시 뜨는 결과 화면)의 UI를 구성해두었습니다.
이부분도 현재 데이터가 없는 경우의 UI가 미흡한데, 디자인쪽에 문의 후 수정 예정입니다.

추가로 Tag 컴포넌트가 원래 children으로 `관련타일` `관련데크` 만 가능하던 것을 활동, 아티스트명으로 직접 표시가 가능하도록 수정했습니다. 이에 따라 Tag를 사용하는 컴포넌트들도 조금씩 수정했습니다.

마이타일, 타임타일 검색 결과의 경우 검색 키워드에 해당하는 부분을 파란색으로 하이라이팅 되게끔 처리해두었습니다. 
지금 전체보기는 처리하진 않았는데 개별 검색 결과 화면 처리하면서 연결해두겠습니다 

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

<img width="1067" height="861" alt="스크린샷 2025-09-23 150858" src="https://github.com/user-attachments/assets/0364629b-178b-44eb-a66e-95139e5921a9" />
<img width="1260" height="786" alt="스크린샷 2025-09-23 151812" src="https://github.com/user-attachments/assets/ef46ac51-f94e-426d-88a2-3b4038bb0df0" />


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->

- 현재 마이타일 검색 결과 부분의 유저 프로필 이미지가 불러와지지않고 깨지는 문제가 발생합니다.  다른 부분의 사진은 다 잘 불러와지고있어서  이건 백엔드측에서 수정해주시면 될 것 같아 확인만 해두셔도 될 것 같습니다!

- 현재 특정문자 (ex. &Team)를 검색하면 query때문인지 client side exception 오류가 뜨는데 해결해보겠습니다.

- 타임타일 검색 결과 부분에 피그마엔 관련 타일, 데크 태그도 같이 들어있는데 지금 백에서 보내주는 데이터에는 이 부분이 없어서 당장 배포환경에서 확인할 수는 없습니다. 일단 없을 경우, 있을 경우 모두 처리해두어서 백에서 보내주시게되면 피그마처럼 구현이 완료될 것 같습니다.
![searchgif3](https://github.com/user-attachments/assets/4c6039e7-7899-406d-94bf-808e3832b053)
UI 보여드리려고 목데이터로 넣어본건데(그래서 사진이 깨짐)
관련 데크나 타일 정보가 들어오면 이런 식으로 조회됩니다! 태그가 많아지면 스크롤되게 했습니다.

- 전체 검색 화면에서 필요한 새 컴포넌트들을 스토리북을 통해 구현해두었습니다. PR에 달릴 코멘트 링크로 확인 가능합니당
- 변경된 태그컴포넌트도 스토리북 통해 확인 가능합니다.
