### PR TITLE
[FIX] workflow pr 분기 설정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -36,6 +36,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Comment PR with Storybook URL
+        if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/src/components/atoms/UserProfileCard/UserProfileCard.stories.ts
+++ b/src/components/atoms/UserProfileCard/UserProfileCard.stories.ts
@@ -6,7 +6,6 @@ const meta = {
   component: UserProfileCard,
   tags: ["autodocs"],
   parameters: {
-    componentSubtitle: "UserProfileCard 컴포넌트",
     docs: {
       description: {
         component: `


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
workflow pr 분기 설정해두었습니다.

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
스토리북이 pr 올라올때만 재배포되게 되어있어서 각 pr올리는 브랜치들에서 재배포되면서 스토리북 전체 library 최신화가 안되는 문제를 발견, 이를 해결하기 위해 워크플로우에 develop에 push시에도 재배포되도록 수정했습니다. 

기존부터 있던 pr시 코멘트에 링크가 달리게하는 부분때문에 머지(푸시)시에 해당 부분에서 pr이 없다는 오류가 발생했는데 이를 해결하기 위해 분기를 두어 pr이 아닐 경우엔 패스하도록 했습니다. 이제 머지될때마다 develop에서 재배포가 되는 것이라 스토리북 전체 최신화가 되어있어서 링크 들어가셔서 쉽게 확인하실 수 있습니다! 

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

<img width="1830" height="658" alt="스크린샷 2025-09-23 165729" src="https://github.com/user-attachments/assets/57e54d9b-9747-4ec5-86fe-57a4e67a8cb3" />
이렇게 develop에서 최신화가 안돼서 build에서 다른 브랜치의 스토리북으로 확인하면 되긴했는데 전체 최신화가 안되고있었습니다.

<img width="1918" height="843" alt="스크린샷 2025-09-23 165736" src="https://github.com/user-attachments/assets/6bc7eb23-2773-4741-8094-8c0d82c2e18e" />
이제 머지시에 develop에서 재배포되므로 library 탭에서도 최신 버전의 스토리북을 확인가능합니다.

<img width="1919" height="859" alt="스크린샷 2025-09-23 165754" src="https://github.com/user-attachments/assets/56b478d0-6ae2-4922-8974-37c48da9789a" />

`view storybook` 누르면 테스트 가능합니다.

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->

워크플로우 수정하면서 pnpm이나 chromatic 버전업을 진행했습니다. 참고용으로 적어둡니다! 