### PR TITLE
[FEAT] 검색어 제안 기능, 검색 빈 화면 UI, 토글 컴포넌트 생성

### DIFF
--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -17,6 +17,7 @@ import { DeckResult } from "@/components/Search/SearchResult/DeckResult";
 import { UserResult } from "@/components/Search/SearchResult/UserResult";
 import { MyTileResult } from "@/components/Search/SearchResult/MyTileResult";
 import { TimeTileResult } from "@/components/Search/SearchResult/TimeTileResult";
+import { BlankResearch } from "@/components/Search/SearchResult/BlankResearch";
 
 const SearchClient = () => {
   const router = useRouter();
@@ -125,6 +126,7 @@ const SearchClient = () => {
             }
           />
         )}
+        {!loading && searchCount === 0 && <BlankResearch />}
       </Wrapper>
     </Container>
   );

--- a/src/app/search/SearchClient.tsx
+++ b/src/app/search/SearchClient.tsx
@@ -11,7 +11,7 @@ import {
   SearchUser,
 } from "@/model/components/SearchType";
 import { theme } from "@/styles/theme";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { SearchHeader } from "@/components/Search/SearchResult/SearchHeader";
 import { DeckResult } from "@/components/Search/SearchResult/DeckResult";
 import { UserResult } from "@/components/Search/SearchResult/UserResult";
@@ -19,6 +19,7 @@ import { MyTileResult } from "@/components/Search/SearchResult/MyTileResult";
 import { TimeTileResult } from "@/components/Search/SearchResult/TimeTileResult";
 
 const SearchClient = () => {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get("query") || "";
   const [artists, setArtists] = useState<SearchArtist[]>([]);
@@ -27,6 +28,7 @@ const SearchClient = () => {
   const [events, setEvents] = useState<SearchEvent[]>([]);
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<SearchResponse | null>(null);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
 
   const searchCount = response
     ? response.artistCount +
@@ -48,17 +50,33 @@ const SearchClient = () => {
           setEvents(res.data.events);
           setArtists(res.data.artists);
           setUsers(res.data.users);
-          console.log(res.data);
+
+          const total =
+            res.data.artistCount +
+            res.data.userCount +
+            res.data.postCount +
+            res.data.eventCount;
+          if (total === 0) {
+            const suggestRes = await searchApi.getSuggestions(query);
+            if (suggestRes.isSuccess) {
+              setSuggestions(suggestRes.data.suggestions);
+            }
+          } else {
+            setSuggestions([]);
+          }
         } else {
+          setResponse(null);
           setResults([]);
           setEvents([]);
           setArtists([]);
           setUsers([]);
+          setSuggestions([]);
         }
       } catch (error) {
         console.error(error);
         setResults([]);
         setEvents([]);
+        setSuggestions([]);
       } finally {
         setLoading(false);
       }
@@ -71,7 +89,7 @@ const SearchClient = () => {
     <Container>
       <Wrapper>
         {loading && <p>로딩 중...</p>}
-        {!loading && response && (
+        {!loading && response && searchCount > 0 && (
           <>
             <SearchHeader searchCount={searchCount} />
             <DeckResult
@@ -98,6 +116,15 @@ const SearchClient = () => {
             />
           </>
         )}
+        {!loading && searchCount === 0 && suggestions.length > 0 && (
+          <SearchHeader
+            searchCount={searchCount}
+            suggestion={suggestions[1]}
+            onClickSuggestion={(word) =>
+              router.push(`/search?query=${encodeURIComponent(word)}`)
+            }
+          />
+        )}
       </Wrapper>
     </Container>
   );
@@ -120,13 +147,4 @@ const Wrapper = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 24px;
-`;
-
-const ResultItem = styled.div`
-  width: 100%;
-  padding: 32px;
-  border: 1px solid ${theme.palette.primary_300};
-  border-radius: 20px;
-  margin-bottom: 24px;
-  background: ${theme.palette.primary_20};
 `;

--- a/src/app/search/mytile/SearchMyTileClient.tsx
+++ b/src/app/search/mytile/SearchMyTileClient.tsx
@@ -52,7 +52,11 @@ export default function SearchMyTileClient() {
   return (
     <Container>
       <Wrapper>
-        <SearchDetailHeader children="마이타일" searchCount={totalCount} />
+        <SearchDetailHeader
+          children="마이타일"
+          searchCount={totalCount}
+          isMyTile={true}
+        />
         <PostWrapper>
           <MyTilePost posts={posts} highlightWord={query} gridMode={true} />
         </PostWrapper>

--- a/src/components/Search/SearchDetail/SearchDetailHeader.tsx
+++ b/src/components/Search/SearchDetail/SearchDetailHeader.tsx
@@ -1,34 +1,51 @@
 import { MoveLeftIcon } from "@/assets/icons/MoveLeftIcon";
 import { Text } from "@/components/atoms/Text";
+import { ToggleButton } from "@/components/atoms/ToggleButton";
+import { theme } from "@/styles/theme";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
+import { useState } from "react";
 
 interface SearchDetailHeaderProps {
   children: string;
   searchCount: number;
+  isMyTile?: boolean;
 }
+
 export const SearchDetailHeader = ({
   children,
   searchCount,
+  isMyTile,
 }: SearchDetailHeaderProps) => {
   const router = useRouter();
+  const [variant, setVariant] = useState<"default" | "images">("default");
 
   return (
-    <Container>
-      <Wrapper>
-        <div style={{ cursor: "pointer" }} onClick={() => router.back()}>
-          <MoveLeftIcon />
-        </div>
-        <TextWrapper>
-          <Text typo="H1" color="primary_700" children={children} />
-          <Text typo="Body_3" color="gray_1000">
-            {searchCount}개의 검색 결과가 있습니다.
-          </Text>
-        </TextWrapper>
-      </Wrapper>
-    </Container>
+    <TopContainer>
+      <Container>
+        <Wrapper>
+          <div style={{ cursor: "pointer" }} onClick={() => router.back()}>
+            <MoveLeftIcon />
+          </div>
+          <TextWrapper>
+            <Text typo="H1" color="primary_700" children={children} />
+            <Text typo="Body_3" color="gray_1000">
+              {searchCount}개의 검색 결과가 있습니다.
+            </Text>
+          </TextWrapper>
+        </Wrapper>
+      </Container>
+      {isMyTile && <ToggleButton variant={variant} onChange={setVariant} />}
+    </TopContainer>
   );
 };
+
+const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+`;
 
 const Container = styled.div`
   display: flex;

--- a/src/components/Search/SearchResult/BlankResearch.tsx
+++ b/src/components/Search/SearchResult/BlankResearch.tsx
@@ -1,0 +1,25 @@
+import { Text } from "@/components/atoms/Text";
+import { theme } from "@/styles/theme";
+import styled from "styled-components";
+
+export const BlankResearch = () => {
+  return (
+    <Container>
+      <Text typo="Body_3" children="검색 결과가 없습니다." />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  width: 1200px;
+  height: 400px;
+  padding: 24px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  border-radius: 20px;
+  border: 1px solid ${theme.palette.primary_300};
+  background: ${theme.palette.primary_20};
+`;

--- a/src/components/Search/SearchResult/SearchHeader.tsx
+++ b/src/components/Search/SearchResult/SearchHeader.tsx
@@ -1,24 +1,54 @@
 import { Text } from "@/components/atoms/Text";
+import { FlexBox } from "@/components/layouts/FlexBox";
 import { theme } from "@/styles/theme";
 import styled from "styled-components";
 
 interface SearchHeaderProps {
   searchCount: number;
+  suggestion?: string;
+  onClickSuggestion?: (keyword: string) => void;
 }
 
-export const SearchHeader = ({ searchCount }: SearchHeaderProps) => {
+export const SearchHeader = ({
+  searchCount,
+  suggestion,
+  onClickSuggestion,
+}: SearchHeaderProps) => {
   return (
     <Container>
       <ResultText>
-        <Text typo="H5" children="전체 검색 결과" />
+        <Text typo="H5">전체 검색 결과</Text>
       </ResultText>
       <SearchResultText>
-        <Text typo="Body_1" color="primary_600" children={searchCount} />
-        <Text
-          typo="Body_3"
-          color="gray_800"
-          children="건의 검색 결과가 있습니다."
-        />
+        <FlexBox>
+          <Text typo="Body_1" color="primary_600">
+            {searchCount}
+          </Text>
+          <Text typo="Body_3" color="gray_800">
+            건의 검색 결과가 있습니다.
+          </Text>
+        </FlexBox>
+        {searchCount === 0 && suggestion && (
+          <div>
+            <SuggestDiv>
+              <SuggestText>
+                <Text typo="Caption_1" color="gray_600" children="제안" />
+              </SuggestText>
+              <SuggestDetailDiv>
+                <SuggestionText onClick={() => onClickSuggestion?.(suggestion)}>
+                  <Text
+                    typo="Body_1"
+                    color="primary_600"
+                    children={suggestion}
+                  />
+                </SuggestionText>
+                <Text typo="Body_3" color="gray_800">
+                  의 검색 결과를 보시겠어요?
+                </Text>
+              </SuggestDetailDiv>
+            </SuggestDiv>
+          </div>
+        )}
       </SearchResultText>
     </Container>
   );
@@ -41,10 +71,40 @@ const ResultText = styled.div`
 
 const SearchResultText = styled.div`
   display: flex;
+  align-items: center;
   width: 1046px;
   height: 48px;
   padding: 9px 16px;
-  align-items: center;
   border-radius: 10px;
   background: ${theme.palette.gray_50};
+  gap: 16px;
+`;
+
+const SuggestionText = styled.div`
+  color: ${theme.palette.primary_600};
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const SuggestDiv = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const SuggestText = styled.div`
+  display: flex;
+  padding: 4px 8px;
+  align-items: center;
+  gap: 4px;
+  border-radius: 15px;
+  border: 1px solid ${theme.palette.gray_600};
+`;
+
+const SuggestDetailDiv = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
 `;

--- a/src/components/atoms/ToggleButton/ToggleButton.stories.ts
+++ b/src/components/atoms/ToggleButton/ToggleButton.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<typeof ToggleButton> = {
       description: {
         component: `
 - variant 값으로 토글 값 중 하나를 선택할 수 있습니다.
-- children으로 태그에 표시할 텍스트를 전달합니다.`,
+- onChange로 토글 상태를 변경합니다.`,
       },
     },
   },

--- a/src/components/atoms/ToggleButton/ToggleButton.stories.ts
+++ b/src/components/atoms/ToggleButton/ToggleButton.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ToggleButton } from ".";
+
+const meta: Meta<typeof ToggleButton> = {
+  title: "Atom/ToggleButton",
+  component: ToggleButton,
+  tags: ["autodocs"],
+  parameters: {
+    componentSubtitle: "토글 버튼 컴포넌트",
+    docs: {
+      description: {
+        component: `
+- variant 값으로 토글 값 중 하나를 선택할 수 있습니다.
+- children으로 태그에 표시할 텍스트를 전달합니다.`,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "images"],
+      description: "토글 종류",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleButton>;
+
+export const DefaultToggleButton: Story = {
+  args: {
+    variant: "default",
+  },
+};
+
+export const ImagesToggleButton: Story = {
+  args: {
+    variant: "images",
+  },
+};

--- a/src/components/atoms/ToggleButton/index.tsx
+++ b/src/components/atoms/ToggleButton/index.tsx
@@ -1,0 +1,68 @@
+import { theme } from "@/styles/theme";
+import styled from "styled-components";
+
+interface ToggleButtonProps {
+  variant: "default" | "images";
+  onChange: (value: "default" | "images") => void;
+}
+
+export const ToggleButton = ({ variant, onChange }: ToggleButtonProps) => {
+  return (
+    <TopContainer>
+      <Container>
+        <TogButton
+          $active={variant === "default"}
+          onClick={() => onChange("default")}
+        >
+          전체 보기
+        </TogButton>
+        <TogButton
+          $active={variant === "images"}
+          onClick={() => onChange("images")}
+        >
+          이미지 모아보기
+        </TogButton>
+      </Container>
+    </TopContainer>
+  );
+};
+
+const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+`;
+
+const Container = styled.div`
+  display: flex;
+  padding: 7px 8px;
+  align-items: center;
+  border-radius: 24px;
+  border: 1px solid ${theme.palette.primary_500};
+  background: ${theme.palette.gray_0};
+  box-shadow: 0 4px 4px 0 rgba(159, 198, 255, 0.15);
+`;
+
+const TogButton = styled.button<{ $active: boolean }>`
+  display: flex;
+  height: 32px;
+  padding: 9px 12px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 20px;
+  border: none;
+  cursor: pointer;
+
+  background: ${({ $active }) =>
+    $active ? `${theme.palette.primary_300}` : `${theme.palette.gray_0}`};
+  color: ${({ $active }) =>
+    $active ? `${theme.palette.primary_900}` : `${theme.palette.gray_1000}`};
+
+  font-family: "Pretendard-Medium";
+  font-size: 14px;
+  font-style: normal;
+  font-weight: ${({ $active }) => ($active ? "500" : "400")};
+  line-height: ${({ $active }) => ($active ? "130%" : "150%")};
+`;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
검색어 제안 기능, 검색 빈 화면 UI, 토글 컴포넌트 생성했습니다.

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- 사용자가 검색어를 잘못 입력했을 경우의 검색어 제안 기능을 연결해두었습니다.
- 검색 결과가 없는 경우의 ui를 피그마 디자인대로 수정해두었습니다.
- 마이타일 검색 상세페이지에 필요한 토글 버튼 컴포넌트를 생성해두었습니다. => 기능 연결은 추후 개발 필요

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="1684" height="646" alt="스크린샷 2025-10-01 184937" src="https://github.com/user-attachments/assets/935a6a17-f75f-4d57-bf52-cd66b204c0e4" />
<img width="867" height="722" alt="스크린샷 2025-10-01 184951" src="https://github.com/user-attachments/assets/c44f3372-1b91-476e-84bc-4ce0e91ccc73" />


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
지금 검색어 제안 기능 관련 오류? 가 살짝 있는데 이거 관련해서도 회의록에 자세히 남기겠습니다. 