### PR TITLE
[FEAT] 마이타일 이미지 모아보기

### DIFF
--- a/src/apis/searchApi.ts
+++ b/src/apis/searchApi.ts
@@ -55,4 +55,11 @@ export const searchApi = {
     });
     return res.data;
   },
+
+  searchImage: async (query: string, lastPostId?: number) => {
+    const res = await authAxios.get("/search/posts/images", {
+      params: { query, lastPostId },
+    });
+    return res.data;
+  },
 };

--- a/src/app/search/deck/SearchDeckClient.tsx
+++ b/src/app/search/deck/SearchDeckClient.tsx
@@ -59,17 +59,21 @@ export default function SearchDeckClient() {
       <Wrapper>
         <SearchDetailHeader children="데크" searchCount={totalCount} />
         <PostWrapper>
-          <ProfileRow>
-            {artists.map((artist) => (
-              <DeckProfile
-                key={artist.id}
-                name={artist.name}
-                imageUrl={artist.imageUrl}
-              />
-            ))}
-          </ProfileRow>
+          {artists.length === 0 ? (
+            <EmptyText>검색 결과가 없습니다.</EmptyText>
+          ) : (
+            <ProfileRow>
+              {artists.map((artist) => (
+                <DeckProfile
+                  key={artist.id}
+                  name={artist.name}
+                  imageUrl={artist.imageUrl}
+                />
+              ))}
+            </ProfileRow>
+          )}
         </PostWrapper>
-        {totalPages > 0 && (
+        {totalPages > 0 && artists.length > 0 && (
           <PaginationComponent
             page={page}
             totalPages={totalPages}
@@ -116,4 +120,17 @@ const ProfileRow = styled.div`
   gap: 16px 12px;
   align-self: stretch;
   flex-wrap: wrap;
+`;
+
+const EmptyText = styled.div`
+  display: flex;
+  width: 1136px;
+  height: 88px;
+  padding: 24px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  border-radius: 20px;
+  background: ${theme.palette.primary_20};
 `;

--- a/src/app/search/mytile/SearchMyTileClient.tsx
+++ b/src/app/search/mytile/SearchMyTileClient.tsx
@@ -1,26 +1,36 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import styled from "styled-components";
 import { searchApi } from "@/apis/searchApi";
 import { SearchDetailHeader } from "@/components/Search/SearchDetail/SearchDetailHeader";
-import { SearchPost } from "@/model/components/SearchType";
+import { ImageSearchPost, SearchPost } from "@/model/components/SearchType";
 import PaginationComponent from "@/components/mypage/PaginationComponent";
 import { MyTilePost } from "@/components/Search/SearchResult/MyTilePost";
 import { theme } from "@/styles/theme";
+import { MyTileImageGrid } from "@/components/Search/SearchResult/MyTileImageGrid";
 
 export default function SearchMyTileClient() {
   const searchParams = useSearchParams();
   const query = searchParams.get("query") || "";
 
   const [posts, setPosts] = useState<SearchPost[]>([]);
+  const [imagePosts, setImagePosts] = useState<ImageSearchPost[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
 
+  const [variant, setVariant] = useState<"default" | "images">("default");
+
+  const [lastPostId, setLastPostId] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
   useEffect(() => {
-    if (!query) return;
+    if (variant !== "default" || !query) return;
 
     const fetchPosts = async () => {
       try {
@@ -31,19 +41,63 @@ export default function SearchMyTileClient() {
           setTotalPages(res.data.totalPages);
         } else {
           setPosts([]);
-          setTotalCount(0);
-          setTotalPages(1);
         }
       } catch (err) {
         console.error(err);
         setPosts([]);
-        setTotalCount(0);
-        setTotalPages(1);
       }
     };
 
     fetchPosts();
-  }, [query, page]);
+  }, [variant, query, page]);
+
+  const fetchImagePosts = async () => {
+    if (!query || loading || !hasNext || variant !== "images") return;
+
+    setLoading(true);
+    try {
+      const res = await searchApi.searchImage(query, lastPostId || undefined);
+
+      if (res.isSuccess && res.data) {
+        setImagePosts((prev: ImageSearchPost[]) => [
+          ...prev,
+          ...res.data.posts.filter(
+            (post: ImageSearchPost) => !prev.some((p) => p.id === post.id)
+          ),
+        ]);
+        setHasNext(res.data.hasNext);
+        setLastPostId(res.data.lastPostId);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (variant === "images") {
+      setImagePosts([]);
+      setHasNext(true);
+      setLastPostId(null);
+    }
+  }, [query, variant]);
+
+  useEffect(() => {
+    if (!observerRef.current || variant !== "images") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNext && !loading) {
+          fetchImagePosts();
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [observerRef, hasNext, loading, variant]);
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
@@ -56,11 +110,21 @@ export default function SearchMyTileClient() {
           children="마이타일"
           searchCount={totalCount}
           isMyTile={true}
+          variant={variant}
+          onChange={setVariant}
         />
         <PostWrapper>
-          <MyTilePost posts={posts} highlightWord={query} gridMode={true} />
+          {variant === "default" ? (
+            <MyTilePost posts={posts} highlightWord={query} gridMode={true} />
+          ) : (
+            <>
+              <MyTileImageGrid posts={imagePosts} />
+              <div ref={observerRef} style={{ height: 1 }} />
+              {loading && <LoadingText>로딩 중...</LoadingText>}
+            </>
+          )}
         </PostWrapper>
-        {totalPages > 0 && (
+        {variant === "default" && totalPages > 0 && (
           <PaginationComponent
             page={page}
             totalPages={totalPages}
@@ -97,4 +161,10 @@ const PostWrapper = styled.div`
   border-radius: 20px;
   border: 1px solid ${theme.palette.primary_300};
   background: ${theme.palette.primary_20};
+`;
+
+const LoadingText = styled.div`
+  text-align: center;
+  padding: 16px;
+  color: ${theme.palette.gray_500};
 `;

--- a/src/app/search/timetile/SearchTimeTileClient.tsx
+++ b/src/app/search/timetile/SearchTimeTileClient.tsx
@@ -54,13 +54,17 @@ export default function SearchTimeTileClient() {
       <Wrapper>
         <SearchDetailHeader children="타임타일" searchCount={totalCount} />
         <PostWrapper>
-          {events.map((event) => (
-            <TimeTileCard
-              key={event.groupId}
-              event={event}
-              highlightWord={query}
-            />
-          ))}
+          {events.length === 0 ? (
+            <EmptyText>검색 결과가 없습니다.</EmptyText>
+          ) : (
+            events.map((event) => (
+              <TimeTileCard
+                key={event.groupId}
+                event={event}
+                highlightWord={query}
+              />
+            ))
+          )}
         </PostWrapper>
         {totalPages > 0 && (
           <PaginationComponent
@@ -98,5 +102,18 @@ const PostWrapper = styled.div`
   align-self: stretch;
   border-radius: 20px;
   border: 1px solid ${theme.palette.primary_300};
+  background: ${theme.palette.primary_20};
+`;
+
+const EmptyText = styled.div`
+  display: flex;
+  width: 1136px;
+  height: 88px;
+  padding: 24px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  border-radius: 20px;
   background: ${theme.palette.primary_20};
 `;

--- a/src/app/search/user/SearchUserClient.tsx
+++ b/src/app/search/user/SearchUserClient.tsx
@@ -59,16 +59,20 @@ export default function SearchUserClient() {
       <Wrapper>
         <SearchDetailHeader children="유저" searchCount={totalCount} />
         <PostWrapper>
-          <ProfileRow>
-            {users.map((user, idx) => (
-              <UserProfileCard
-                key={idx}
-                name={user.nickname}
-                imageUrl={user.imageUrl}
-                introduction={user.introduction}
-              />
-            ))}
-          </ProfileRow>
+          {users.length === 0 ? (
+            <EmptyText>검색 결과가 없습니다.</EmptyText>
+          ) : (
+            <ProfileRow>
+              {users.map((user, idx) => (
+                <UserProfileCard
+                  key={idx}
+                  name={user.nickname}
+                  imageUrl={user.imageUrl}
+                  introduction={user.introduction}
+                />
+              ))}
+            </ProfileRow>
+          )}
         </PostWrapper>
         {totalPages > 0 && (
           <PaginationComponent
@@ -115,4 +119,17 @@ const ProfileRow = styled.div`
   flex-wrap: wrap;
   gap: 14px;
   justify-content: flex-start;
+`;
+
+const EmptyText = styled.div`
+  display: flex;
+  width: 1136px;
+  height: 88px;
+  padding: 24px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  border-radius: 20px;
+  background: ${theme.palette.primary_20};
 `;

--- a/src/components/Search/SearchDetail/SearchDetailHeader.tsx
+++ b/src/components/Search/SearchDetail/SearchDetailHeader.tsx
@@ -10,15 +10,18 @@ interface SearchDetailHeaderProps {
   children: string;
   searchCount: number;
   isMyTile?: boolean;
+  variant?: "default" | "images";
+  onChange?: (value: "default" | "images") => void;
 }
 
 export const SearchDetailHeader = ({
   children,
   searchCount,
   isMyTile,
+  variant = "default",
+  onChange,
 }: SearchDetailHeaderProps) => {
-  const router = useRouter();
-  const [variant, setVariant] = useState<"default" | "images">("default");
+  const router = useRouter();;
 
   return (
     <TopContainer>
@@ -35,7 +38,9 @@ export const SearchDetailHeader = ({
           </TextWrapper>
         </Wrapper>
       </Container>
-      {isMyTile && <ToggleButton variant={variant} onChange={setVariant} />}
+     {isMyTile && onChange && (
+        <ToggleButton variant={variant} onChange={onChange} />
+      )}
     </TopContainer>
   );
 };

--- a/src/components/Search/SearchResult/MyTileImageGrid.tsx
+++ b/src/components/Search/SearchResult/MyTileImageGrid.tsx
@@ -1,0 +1,99 @@
+import styled from "styled-components";
+import { ImageSearchPost } from "@/model/components/SearchType";
+import { theme } from "@/styles/theme";
+
+interface MyTileImageGridProps {
+  posts: ImageSearchPost[];
+}
+
+export const MyTileImageGrid = ({ posts }: MyTileImageGridProps) => {
+  if (posts.length === 0) return <EmptyText>검색 결과가 없습니다.</EmptyText>;
+
+  return (
+    <MasonryWrapper>
+      <MasonryGrid>
+        {posts.map((post) => (
+          <ImageItem key={post.id}>
+            <img src={post.imageUrl} alt={post.title} loading="lazy" />
+            <InfoBox>
+              <Title>{post.title}</Title>
+            </InfoBox>
+          </ImageItem>
+        ))}
+      </MasonryGrid>
+    </MasonryWrapper>
+  );
+};
+
+const MasonryWrapper = styled.div`
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+const MasonryGrid = styled.div`
+  column-count: 3;
+  column-gap: 16px;
+
+  @media (max-width: 1024px) {
+    column-count: 2;
+  }
+
+  @media (max-width: 600px) {
+    column-count: 1;
+  }
+`;
+
+const ImageItem = styled.div`
+  display: block;
+  break-inside: avoid;
+  margin-bottom: 16px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: ${theme.palette.gray_0};
+  width: 100%;
+
+  img {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: 20px;
+  }
+`;
+
+const InfoBox = styled.div`
+  display: flex;
+  padding: 16px 16px 8px 16px;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+`;
+
+const Title = styled.div`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  flex: 1 0 0;
+  overflow: hidden;
+  color: #000;
+
+  text-overflow: ellipsis;
+  font-family: "Pretendard-Regular";
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%;
+`;
+
+const EmptyText = styled.div`
+  display: flex;
+  width: 1136px;
+  height: 88px;
+  padding: 24px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  border-radius: 20px;
+  background: ${theme.palette.primary_20};
+`;

--- a/src/model/components/SearchType.ts
+++ b/src/model/components/SearchType.ts
@@ -68,3 +68,20 @@ export interface SearchPostResponse {
   hasPrevious: boolean;
   isLast: boolean;
 }
+
+export interface ImageSearchPost {
+  id: number;
+  title: string;
+  imageUrl: string;
+}
+
+export interface ImageSearchResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  data: {
+    posts: ImageSearchPost[];
+    hasNext: boolean;
+    lastPostId: number;
+  };
+}


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
검색페이지 마이타일 이미지 모아보기 기능을 구현했습니다.

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- 마이타일 이미지 모아보기 탭
- 이미지들 masonry 레이아웃으로 띄우기
- 무한스크롤 반영
- 전체 검색 전체 보기 클릭 시 빈화면 UI 변경

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="1438" height="867" alt="스크린샷 2025-10-07 214442" src="https://github.com/user-attachments/assets/b75fa630-9a35-4c4f-ac84-ad018698c709" />


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->