### PR TITLE
[FIX] 데크 대표스케줄 너비 수정

### DIFF
--- a/src/components/Deck/YearScroller.tsx
+++ b/src/components/Deck/YearScroller.tsx
@@ -68,9 +68,11 @@ export const YearScroller = ({
               {hoveredYear === year && yearSchedules[year] && (
                 <Tooltip>
                   {yearSchedules[year].map((schedule, idx) => (
-                    <Text key={idx} typo="Caption_4" color="gray_900">
-                      {schedule}
-                    </Text>
+                    <div key={`${year}-${idx}`} style={{ width: "188px" }}>
+                      <Text typo="Caption_4" color="gray_900">
+                        {schedule}
+                      </Text>
+                    </div>
                   ))}
                 </Tooltip>
               )}
@@ -134,7 +136,7 @@ const Tooltip = styled.div`
   padding: 12px;
   flex-direction: column;
   align-items: flex-start;
-  gap: 12px;
+  gap: 20px;
   background-color: ${theme.palette.gray_0};
   border: 1px solid ${theme.palette.gray_200};
   border-radius: 8px;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
데크의 아티스트 대표 스케줄 툴팁 너비를 수정합니다.

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- 대표 스케줄 툴팁의 너비를 188px로 설정합니다. 
- max width로 설정 시에는 전처럼 그대로 보여져서 디자인 의도에 맞춰 width를 188px로 설정했습니다.

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
<img width="508" height="279" alt="image" src="https://github.com/user-attachments/assets/636ef0a8-60a4-44b4-bbe0-b81b2092392a" />

![qa gif](https://github.com/user-attachments/assets/50a9c0d7-0697-4052-adc0-cfe9607d9d24)




## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->